### PR TITLE
Use official "cockpit-manifest" launchable type

### DIFF
--- a/org.cockpit-project.starter.metainfo.xml
+++ b/org.cockpit-project.starter.metainfo.xml
@@ -11,5 +11,5 @@
     </p>
   </description>
   <extends>cockpit.desktop</extends>
-  <launchable type="cockpit-package">starter-cockpit</launchable>
+  <launchable type="cockpit-manifest">starter-cockpit</launchable>
 </component>


### PR DESCRIPTION
The "cockpit-package" type was only a proposal.

Fixes #7