### PR TITLE
test: Use test/common Cockpit API from latest stable tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,16 @@ check: node_modules/react-lite $(VM_IMAGE) test/common
 	TEST_AUDIT_NO_SELINUX=1 test/check-starter-kit
 
 # checkout Cockpit's bots/ directory for standard test VM images and API to launch them
+# must be from cockpit's master, as only that has current and existing images; but testvm.py API is stable
 bots:
 	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git
 	git checkout --force FETCH_HEAD -- bots/
 	git reset bots
 
-# checkout Cockpit's test API
+# checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
+# when you start a new project, use the latest relese, and update it from time to time
 test/common:
-	# when running in CI, update FETCH_HEAD to cockpit repo
-	if git remote | grep -qF test; then git fetch origin master; fi
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 163
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 


### PR DESCRIPTION
Cockpit's testlib.py has no stable API guarantee, so check it out from a
stable tag instead of master. This should occasionally be bumped to stay
current.

Note that the same does not apply to bots/: Stable tags are useless
there as the old images get cleaned up. Also, testvm.py API needs to be
stable for Cockpit's own purposes already.

This needs to drop the slight git checkout optimization, but this also
makes the code more symmetric and easier to understand.