### PR TITLE
Remove some instances of "starter kit"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *~
 *.retry
-cockpit-starter-kit*.tar.gz
-cockpit-starter-kit-*.rpm
+*.tar.gz
+*.rpm
 node_modules/
 dist/
 /.vagrant

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ vm: $(VM_IMAGE)
 
 # run the browser integration tests; skip check for SELinux denials
 check: node_modules/react-lite $(VM_IMAGE) test/common
-	TEST_AUDIT_NO_SELINUX=1 test/check-starter-kit
+	TEST_AUDIT_NO_SELINUX=1 test/check-application
 
 # checkout Cockpit's bots/ directory for standard test VM images and API to launch them
 # must be from cockpit's master, as only that has current and existing images; but testvm.py API is stable

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ duplicate this behavior.
 # Testing
 
 Run `make check` to build an RPM, install it into a standard Cockpit test VM
-(centos-7 by default), and run the test/check-starter-kit integration test on
+(centos-7 by default), and run the test/check-application integration test on
 it. This uses Cockpit's Chrome DevTools Protocol based browser tests, through a
 Python API abstraction. Note that this API is not guaranteed to be stable, so
 if you run into failures and don't want to adjust tests, consider checking out
@@ -28,7 +28,7 @@ After the test VM is prepared, you can manually run the test without rebuilding
 the VM, possibly with extra options for tracing and halting on test failures
 (for interactive debugging):
 
-    TEST_OS=centos-7 test/check-starter-kit -tvs
+    TEST_OS=centos-7 test/check-application -tvs
 
 You can also run the test against a different Cockpit image, for example:
 
@@ -41,3 +41,12 @@ Fedora 26 cloud image. Run `vagrant up` to start it and `vagrant rsync` to
 synchronize the `dist` directory to `/usr/local/share/cockit/starter-kit`. Use
 `vagrant rsync-auto` to automatically sync when contents of the `dist`
 directory change.
+
+# Customizing
+
+After cloning the Starter Kit you should rename the files, package names, and
+labels to your own project's name. Use these commands to find out what to
+change:
+
+    find -iname '*starter*'
+    git grep -i starter

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -21,7 +21,7 @@
 import cockpit from 'cockpit';
 import React from 'react';
 
-export class StarterKit extends React.Component {
+export class Application extends React.Component {
     constructor() {
         super();
 

--- a/src/index.es6
+++ b/src/index.es6
@@ -19,8 +19,8 @@
  */
 
 import React from 'react';
-import { StarterKit } from './starter-kit.jsx';
+import { Application } from './app.jsx';
 
 document.addEventListener("DOMContentLoaded", function () {
-    React.render(React.createElement(StarterKit, {}), document.getElementById('app'));
+    React.render(React.createElement(Application, {}), document.getElementById('app'));
 });

--- a/test/check-application
+++ b/test/check-application
@@ -13,7 +13,7 @@ sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 import testlib
 
 
-class TestStarterKit(testlib.MachineCase):
+class TestApplication(testlib.MachineCase):
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/vm.install
+++ b/test/vm.install
@@ -1,6 +1,6 @@
 #!/bin/sh
 # image-customize script to enable cockpit in test VMs
-# The starter-kit RPM will be installed separately
+# The application RPM will be installed separately
 set -eu
 
 # don't force https:// (self-signed cert)


### PR DESCRIPTION
Rename some files and change some identifiers to be neutral to the
application name. This makes it simpler to change everything to a proper
name when cloning this project.

Document in the README how to find the remaining places to change.