### PR TITLE
Add git tag derived version to tarball and spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.rpm
 node_modules/
 dist/
+/*.spec
 /.vagrant
 package-lock.json
 Test*FAIL*

--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -1,10 +1,10 @@
 Name: cockpit-starter-kit
-Version: 1
+Version: @VERSION@
 Release: 0
 Summary: Cockpit Starter Kit Example Module
 License: LGPLv2.1+
 
-Source: cockpit-starter-kit.tar.gz
+Source: cockpit-starter-kit-%{version}.tar.gz
 BuildArch: noarch
 
 %define debug_package %{nil}


### PR DESCRIPTION
Stop hardcoding the version in the spec file, and put the version into
dist tarballs.