### PR TITLE
Various build system and srpm fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ export TEST_OS
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # one example directory from `npm install` to check if that already ran
 NODE_MODULES_TEST=node_modules/po2json
+# one example file in dist/ from webpack to check if that already ran
+WEBPACK_TEST=dist/index.html
 
-all: dist/index.js
+all: $(WEBPACK_TEST)
 
 #
 # i18n
@@ -60,21 +62,21 @@ dist/po.%.js: po/%.po $(NODE_MODULES_TEST)
 %.spec: %.spec.in
 	sed -e 's/@VERSION@/$(VERSION)/g' $< > $@
 
-dist/index.js: $(NODE_MODULES_TEST) $(wildcard src/*) package.json webpack.config.js $(patsubst %,dist/po.%.js,$(LINGUAS))
+$(WEBPACK_TEST): $(NODE_MODULES_TEST) $(wildcard src/*) package.json webpack.config.js $(patsubst %,dist/po.%.js,$(LINGUAS))
 	NODE_ENV=$(NODE_ENV) npm run build
 
 clean:
 	rm -rf dist/
 	[ ! -e cockpit-$(PACKAGE_NAME).spec.in ] || rm -f cockpit-$(PACKAGE_NAME).spec
 
-install: dist/index.js
+install: $(WEBPACK_TEST)
 	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	mkdir -p $(DESTDIR)/usr/share/metainfo/
 	cp org.cockpit-project.$(PACKAGE_NAME).metainfo.xml $(DESTDIR)/usr/share/metainfo/
 
 # this requires a built source tree and avoids having to install anything system-wide
-devel-install: dist/index.js
+devel-install: $(WEBPACK_TEST)
 	mkdir -p ~/.local/share/cockpit
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ dist/index.js: $(NODE_MODULES_TEST) $(wildcard src/*) package.json webpack.confi
 
 clean:
 	rm -rf dist/
-	rm -rf _install
 	rm -f $(PACKAGE_NAME).spec
 
 install: dist/index.js

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ dist/index.js: $(NODE_MODULES_TEST) $(wildcard src/*) package.json webpack.confi
 
 clean:
 	rm -rf dist/
-	rm -f $(PACKAGE_NAME).spec
+	[ ! -e cockpit-$(PACKAGE_NAME).spec.in ] || rm -f cockpit-$(PACKAGE_NAME).spec
 
 install: dist/index.js
 	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
@@ -80,8 +80,10 @@ devel-install: dist/index.js
 
 # when building a distribution tarball, call webpack with a 'production' environment
 dist-gzip: NODE_ENV=production
-dist-gzip: clean $(NODE_MODULES_TEST) all
-	tar czf cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz --transform 's,^,cockpit-$(PACKAGE_NAME)/,' $$(git ls-files) dist/
+dist-gzip: $(NODE_MODULES_TEST) all cockpit-$(PACKAGE_NAME).spec
+	tar czf cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
+		--exclude cockpit-$(PACKAGE_NAME).spec.in \
+		$$(git ls-files) cockpit-$(PACKAGE_NAME).spec dist/
 
 srpm: dist-gzip cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ dist/po.%.js: po/%.po $(NODE_MODULES_TEST)
 %.spec: %.spec.in
 	sed -e 's/@VERSION@/$(VERSION)/g' $< > $@
 
-$(WEBPACK_TEST): $(NODE_MODULES_TEST) $(wildcard src/*) package.json webpack.config.js $(patsubst %,dist/po.%.js,$(LINGUAS))
+$(WEBPACK_TEST): $(NODE_MODULES_TEST) $(shell find src/ -type f) package.json webpack.config.js $(patsubst %,dist/po.%.js,$(LINGUAS))
 	NODE_ENV=$(NODE_ENV) npm run build
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,18 @@ devel-install: $(WEBPACK_TEST)
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
 # when building a distribution tarball, call webpack with a 'production' environment
+# ship a stub node_modules/ so that `make` works without re-running `npm install`
 dist-gzip: NODE_ENV=production
-dist-gzip: $(NODE_MODULES_TEST) all cockpit-$(PACKAGE_NAME).spec
+dist-gzip: all cockpit-$(PACKAGE_NAME).spec
+	mv node_modules node_modules.release
+	mkdir -p $(NODE_MODULES_TEST)
+	touch -r package.json $(NODE_MODULES_TEST)
+	touch dist/*
 	tar czf cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude cockpit-$(PACKAGE_NAME).spec.in \
-		$$(git ls-files) cockpit-$(PACKAGE_NAME).spec dist/
+		$$(git ls-files) cockpit-$(PACKAGE_NAME).spec dist/ node_modules
+	rm -rf node_modules
+	mv node_modules.release node_modules
 
 srpm: dist-gzip cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \

--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -24,3 +24,5 @@ find %{buildroot} -type f >> files.list
 sed -i "s|%{buildroot}||" *.list
 
 %files -f files.list
+
+%changelog

--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -6,6 +6,7 @@ License: LGPLv2.1+
 
 Source: cockpit-starter-kit-%{version}.tar.gz
 BuildArch: noarch
+BuildRequires: /usr/bin/python3
 
 %define debug_package %{nil}
 

--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -1,6 +1,6 @@
 Name: cockpit-starter-kit
 Version: @VERSION@
-Release: 0
+Release: 1%{?dist}
 Summary: Cockpit Starter Kit Example Module
 License: LGPLv2.1+
 

--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -17,7 +17,7 @@ Cockpit Starter Kit Example Module
 %setup -n cockpit-starter-kit
 
 %build
-make
+# There is nothing to do, release tarballs already have dist/.
 
 %install
 make install DESTDIR=%{buildroot}


### PR DESCRIPTION
With these plus a [cockpituous fix](https://github.com/cockpit-project/cockpituous/pull/194) one now can generate working upstream release tarballs, srpm, and build the srpm in mock (thus no network access or missing dependencies) to generate a working rpm. Tested like this:
```
git clean -ffdx
RELEASE_SOURCE=$PWD/_release/source  ~/upstream/cockpituous/release/release-source 
RELEASE_SOURCE=$PWD/_release/source  RELEASE_SPEC=cockpit-starter-kit.spec RELEASE_SRPM=_release/srpm ~/upstream/cockpituous/release/release-srpm -V
mock _release/cockpit-starter-kit-999-1.fc28.src.rpm
```