### PR TITLE
Add minimal Cockpituous release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ change:
     find -iname '*starter*'
     git grep -i starter
 
+# Automated release
+
+Once your cloned project is ready for a release, you should consider automating
+that.  [Cockpituous release](https://github.com/cockpit-project/cockpituous/tree/master/release)
+aims to fully automate project releases to GitHub, Fedora, Ubuntu, COPR, Docker
+Hub, and other places. The intention is that the only manual step for releasing
+a project is to create a signed tag for the version number; pushing the tag
+then triggers a GitHub webhook that calls a set of release scripts (on
+Cockpit's CI infrastructure).
+
+starter-kit includes an example [cockpitous release script](./cockpituous-release)
+that builds an upstream release tarball and source RPM. Please see the above
+cockpituous documentation for details.
+
 # Further reading
 
  * The [Starter Kit announcement](http://cockpit-project.org/blog/cockpit-starter-kit.html)

--- a/cockpituous-release
+++ b/cockpituous-release
@@ -1,0 +1,16 @@
+# This is a script run to release welder-web through Cockpituous:
+# https://github.com/cockpit-project/cockpituous/tree/master/release
+
+# Anything that start with 'job' may run in a way that it SIGSTOP's
+# itself when preliminary preparition and then gets a SIGCONT in
+# order to complete its work.
+
+RELEASE_SOURCE="_release/source"
+RELEASE_SPEC="cockpit-starter-kit.spec"
+RELEASE_SRPM="_release/srpm"
+
+job release-source
+job release-srpm
+# job release-github
+# job release-copr @myorg/myrepo
+# check cockpituous documentation for available release targets


### PR DESCRIPTION
This only builds a tarball and srpm, and shows a few other example.
Document the intent and point to the cockpituous docs.