### PR TITLE
Simplify spec file

### DIFF
--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -16,14 +16,11 @@ Cockpit Starter Kit Example Module
 %prep
 %setup -n cockpit-starter-kit
 
-%build
-# There is nothing to do, release tarballs already have dist/.
-
 %install
-make install DESTDIR=%{buildroot}
-find %{buildroot} -type f >> files.list
-sed -i "s|%{buildroot}||" *.list
+%make_install
 
-%files -f files.list
+%files
+%{_datadir}/cockpit/*
+%{_datadir}/metainfo/*
 
 %changelog


### PR DESCRIPTION
- Entirely drop `%build` section, as there is nothing to do anyway.
- Use `%make_install` macro.
- Replace the complicated file list wrangling with a simple directory
  enumeration.

Thanks to Igor Gnatenko for the suggestions!

See https://bugzilla.redhat.com/show_bug.cgi?id=1603146