### PR TITLE
test: Really clean up test VM on image preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ rpm: dist-gzip cockpit-$(PACKAGE_NAME).spec
 
 # build a VM with locally built rpm installed
 $(VM_IMAGE): rpm bots
-	rm -f $(VM_IMAGE)
+	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
 	bots/image-customize -v -i cockpit -i `pwd`/cockpit-$(PACKAGE_NAME)-*.noarch.rpm -s $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above


### PR DESCRIPTION
The previous fix (commit 6e05f5b4837) only cleaned
test/images/$(TEST_OS), which is just a symlink to $(TEST_OS).qcow.
Clean the actual image as well.