### PR TITLE
Validate AppStream metainfo during RPM build

### DIFF
--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -6,6 +6,7 @@ License: LGPLv2+
 
 Source: cockpit-starter-kit-%{version}.tar.gz
 BuildArch: noarch
+BuildRequires:  libappstream-glib
 
 Requires: cockpit-system
 
@@ -19,6 +20,7 @@ Cockpit Starter Kit Example Module
 
 %install
 %make_install
+appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 
 %files
 %{_datadir}/cockpit/*


### PR DESCRIPTION
This is a requirement in the Fedora packaging guidelines:
https://docs.fedoraproject.org/en-US/packaging-guidelines/AppData/#_app_data_validate_usage