### PR TITLE
tasks: Minimize races filing issues for bots

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -1,7 +1,16 @@
 #!/bin/sh
 
-# Open issues for things that need doing on a regular basis
-bots/npm-trigger
+# When run automated, randomize to minimize stampeding herd
+if [ -t 0 ]; then
+    chance=10
+else
+    chance=$(shuf -i 0-10 -n 1)
+fi
+
+if [ $chance -gt 9 ]; then
+    # Open issues for things that need doing on a regular basis
+    bots/npm-trigger
+fi
 
 # Find those issues and propose to do them
 bots/issue-scan


### PR DESCRIPTION
We don't need to file or check for these issues on every iteration
through the .tasks script. These will count as "work done" and thus skip
the sleep (even though the "work" lasts only a split-second), and are
prone to creating duplicates.

Similar to https://github.com/cockpit-project/cockpit/commit/af2e934a