### PR TITLE
test: Remove redundant wait_present() calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest relese, and update it from time to time
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 190
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 191
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 

--- a/test/check-application
+++ b/test/check-application
@@ -20,12 +20,10 @@ class TestApplication(testlib.MachineCase):
 
         self.login_and_go("/starter-kit")
         # verify expected heading
-        b.wait_present(".container-fluid h2")
         b.wait_text(".container-fluid h2", "Starter Kit")
 
         # verify expected host name
         hostname = m.execute("hostname").strip()
-        b.wait_present(".container-fluid p")
         b.wait_text(".container-fluid p", "Running on " + hostname)
 
         # change current hostname


### PR DESCRIPTION
These are obsolete since
https://github.com/cockpit-project/cockpit/commit/b1722f5b5d0

Bump cockpit test API accordingly.