### PR TITLE
cockpituous: Fix srpm Release:

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -12,7 +12,7 @@ RELEASE_SPEC="cockpit-starter-kit.spec"
 RELEASE_SRPM="_release/srpm"
 
 job release-source
-job release-srpm
+job release-srpm -V
 
 # Once you have a Fedora package and add the https://pagure.io/user/cockpit
 # user to your project's maintainers, you can also upload to Fedora automatically:


### PR DESCRIPTION
Use release-srpm's `-V` option [1] so that the generated srpm will get a
proper changelog and Release "1" instead of "2".

[1] https://github.com/cockpit-project/cockpituous/commit/abb2bdb5