### PR TITLE
Fix updating of node_modules/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,8 @@ test/common:
 $(NODE_MODULES_TEST): package.json
 	# if it exists already, npm install won't update it; force that so that we always get up-to-date packages
 	rm -f package-lock.json
-	npm install
-	npm prune
+	# unset NODE_ENV, skips devDependencies otherwise
+	env -u NODE_ENV npm install
+	env -u NODE_ENV npm prune
 
 .PHONY: all clean install devel-install dist-gzip srpm rpm check vm update-po


### PR DESCRIPTION
`npm install` does not update/touch an already existing
package-lock.json. Thus after

    make
    touch package.json
    make

a subsequent `make` would still run `npm install`. To fix this, remove
package-lock.json before `npm install`, so that (1) package-lock.json
always gets touched and thus the make rule actually works, and (2)
during development we always get up to date packages (we only really
want the "locking" behaviour for building from release tarballs).

Also run `npm prune` so that switching between git trees with
added/removed modules works correctly.