### PR TITLE
Makefile: Fix image-customize call for multiple rpms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ rpm: dist-gzip cockpit-$(PACKAGE_NAME).spec
 # build a VM with locally built rpm installed
 $(VM_IMAGE): rpm bots
 	rm -f $(VM_IMAGE) $(VM_IMAGE).qcow2
-	bots/image-customize -v -i cockpit -i `pwd`/cockpit-$(PACKAGE_NAME)-*.noarch.rpm -s $(CURDIR)/test/vm.install $(TEST_OS)
+	bots/image-customize -v -i cockpit -i `pwd`/cockpit-$(PACKAGE_NAME)-*$(VERSION)*.noarch.rpm -s $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above
 vm: $(VM_IMAGE)


### PR DESCRIPTION
Ensure that we only install the current rpm into the VM. If there are
older ones in the build tree, image-customize otherwise fails.