### PR TITLE
Add eslint rules for React hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
         },
         "sourceType": "module"
     },
-    "plugins": ["flowtype", "react"],
+    "plugins": ["flowtype", "react", "react-hooks"],
     "rules": {
         "indent": ["error", 4,
             {
@@ -27,6 +27,9 @@
         "prefer-promise-reject-errors": ["error", { "allowEmptyReject": true }],
         "react/jsx-indent": ["error", 4],
         "semi": ["error", "always", { "omitLastInOneLineBlock": true }],
+
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "error",
 
         "camelcase": "off",
         "comma-dangle": "off",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^2.1.2",
     "eslint-plugin-standard": "^4.0.1",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "htmlparser": "^1.7.7",


### PR DESCRIPTION
These make components with simple state (only a few variables) easier to
read and maintain. See https://reactjs.org/docs/hooks-intro.html for
details. Hook are available since React 16.8, and we already depend on 16.10.

We can't use hooks in our actual code, as our only `Application`
component needs a constructor. But this enables the ESLint plugin to
guide developers to the right path if they use hooks.