### PR TITLE
Replace 'extract-text-webpack-plugin' with 'mini-css-extract-plugin'

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^2.1.2",
     "eslint-plugin-standard": "^4.0.1",
-    "extract-text-webpack-plugin": "^4.0.0-beta.0",
+    "mini-css-extract-plugin": "^0.9.0",
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",
     "po2json": "^1.0.0-alpha",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require("path");
 const copy = require("copy-webpack-plugin");
-const extract = require("extract-text-webpack-plugin");
+const extract = require("mini-css-extract-plugin");
 const fs = require("fs");
 const webpack = require("webpack");
 const CompressionPlugin = require("compression-webpack-plugin");
@@ -79,7 +79,7 @@ info.files = files;
 
 var plugins = [
     new copy(info.files),
-    new extract("[name].css")
+    new extract({filename: "[name].css"})
 ];
 
 /* Only minimize when in production mode */
@@ -134,8 +134,17 @@ module.exports = {
             },
             {
                 exclude: /node_modules/,
-                loader: extract.extract('css-loader!sass-loader'),
-                test: /\.scss$/
+                test: /\.scss$/,
+                use: [
+                    extract.loader,
+                    {
+                        loader: 'css-loader',
+                        options: { url: false }
+                    },
+                    {
+                        loader: 'sass-loader',
+                    }
+                ]
             }
         ]
     },


### PR DESCRIPTION
It looks like Webpack is deprecating extract-text-webpack-plugin in favor of
mini-css-extract-plugin.
Discussion can be found here: webpack-contrib/extract-text-webpack-plugin#731