### PR TITLE
Exclude node_modules from webpack watching

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,6 +118,9 @@ module.exports = {
     resolve: {
         modules: [ nodedir ],
     },
+    watchOptions: {
+        ignored: /node_modules/,
+    },
     entry: info.entries,
     externals: externals,
     output: output,


### PR DESCRIPTION
This recently started to overflow inotify, and we don't need that --
it's fine to restart webpack when changing package.json, and it happens
rarely enough.