### PR TITLE
test: Bump test/common to 228

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 224
+	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 228
 	git checkout --force FETCH_HEAD -- test/common
 	git reset test/common
 


### PR DESCRIPTION
On the login page the `Reuse password` checkbox was dropped and that
makes all the tests to fail.
See https://github.com/cockpit-project/cockpit/commit/ef97e7e9a28a