### PR TITLE
Makefile: Replace `git restore` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ src/lib/patternfly/_fonts.scss:
 	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 227
 	mkdir -p pkg/lib/patternfly && git add pkg/lib/patternfly
 	git checkout --force FETCH_HEAD -- pkg/lib/patternfly
-	git restore --staged pkg/lib/patternfly
+	git reset -- pkg/lib/patternfly
 	mkdir -p src/lib && mv pkg/lib/patternfly src/lib/patternfly && rmdir -p pkg/lib
 
 # force serialization of the targets that call git, as they compete for the git lock


### PR DESCRIPTION
This is a relatively recent git feature which is not present in e.g.
Debian 9 yet. Use `git reset` instead, like in the test/common rule.

Fixes #369