### PR TITLE
Makefile: Serialize git commands using flock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,20 +153,18 @@ bots:
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 228
-	git checkout --force FETCH_HEAD -- test/common
-	git reset test/common
+	flock Makefile sh -ec '\
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 228; \
+	    git checkout --force FETCH_HEAD -- test/common; \
+	    git reset test/common'
 
 src/lib/patternfly/_fonts.scss:
-	git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 227
-	mkdir -p pkg/lib/patternfly && git add pkg/lib/patternfly
-	git checkout --force FETCH_HEAD -- pkg/lib/patternfly
-	git reset -- pkg/lib/patternfly
+	flock Makefile sh -ec '\
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 227; \
+	    mkdir -p pkg/lib/patternfly && git add pkg/lib/patternfly; \
+	    git checkout --force FETCH_HEAD -- pkg/lib/patternfly; \
+	    git reset -- pkg/lib/patternfly'
 	mkdir -p src/lib && mv pkg/lib/patternfly src/lib/patternfly && rmdir -p pkg/lib
-
-# force serialization of the targets that call git, as they compete for the git lock
-bots: test/common
-test/common: src/lib/patternfly/_fonts.scss
 
 $(NODE_MODULES_TEST): package.json
 	# if it exists already, npm install won't update it; force that so that we always get up-to-date packages


### PR DESCRIPTION
We previously made directories depend on files for the synthetic
serialization of git commands. git does not track directories, and
time stamps across repos (starter-kit vs. bots) work rather poorly --
for example, this broke "bots" being a symlink to a previously existing
checkout.

Use file locking instead, which is a more direct way of ensuring that
there is only one git operation that affects the current checkout. We
don't need to flock bots/, as that's an independent git repository.