### PR TITLE
Use standard "translate" marker in HTML, fix PO template build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
   - "lts/*"
 script:
   - make
+  - make po/starter-kit.pot

--- a/po/html2po
+++ b/po/html2po
@@ -45,9 +45,9 @@ try {
 }
 
 var opts = stdio.getopt({
-    directory: { key: "d", args: 1, description: "Base directory for input files" },
+    directory: { key: "d", args: 1, description: "Base directory for input files", default: "." },
     output: { key: "o", args: 1, description: "Output file" },
-    from: { key: "f", args: 1, description: "File containing list of input files" },
+    from: { key: "f", args: 1, description: "File containing list of input files", default: "" },
 });
 
 if (!opts.from && opts.args.length < 1) {

--- a/po/manifest2po
+++ b/po/manifest2po
@@ -26,9 +26,9 @@ try {
 }
 
 var opts = stdio.getopt({
-    directory: { key: "d", args: 1, description: "Base directory for input files" },
+    directory: { key: "d", args: 1, description: "Base directory for input files", default: "." },
     output: { key: "o", args: 1, description: "Output file" },
-    from: { key: "f", args: 1, description: "File containing list of input files" },
+    from: { key: "f", args: 1, description: "File containing list of input files", default: "" },
 });
 
 if (!opts.from && opts.args.length < 1) {
@@ -70,11 +70,19 @@ function step() {
     if (path.basename(filename) != "manifest.json")
         return step();
 
-    fs.readFile(filename, { encoding: "utf-8"}, function(err, data) {
+    /* Qualify the filename if necessary */
+    var full = filename;
+    if (opts.directory)
+        full = path.join(opts.directory, filename);
+
+    fs.readFile(full, { encoding: "utf-8"}, function(err, data) {
         if (err)
             fatal(err.message);
 
-        process_manifest(JSON.parse(data));
+        // There are variables which when not substituted can cause JSON.parse to fail
+        // Dummy replace them. None variable is going to be translated anyway
+        safe_data = data.replace(/\@.+?\@/gi, 1);
+        process_manifest(JSON.parse(safe_data));
 
         return step();
     });

--- a/po/po2json
+++ b/po/po2json
@@ -46,10 +46,10 @@ function prepareHeader(header) {
         }
 
         /* A function for the front end */
-        statement = header["plural-forms"];
+	statement = header["plural-forms"];
         if (statement[statement.length - 1] != ';')
             statement += ';';
-        ret = 'function(n) {\nvar nplurals, plural;\n' + statement + '\nreturn plural;\n}';
+	ret = 'function(n) {\nvar nplurals, plural;\n' + statement + '\nreturn plural;\n}';
 
         /* Added back in later */
         delete header["plural-forms"];
@@ -72,7 +72,7 @@ function prepareHeader(header) {
 /* Parse and process the po data */
 function parse() {
     filename = opts.args[0];
-    po2json.parseFile(opts.args[0], { "fuzzy": true }, function(err, jsonData) {
+    po2json.parseFile(opts.args[0], { "fuzzy": false }, function(err, jsonData) {
         var plurals, pos;
 
         if (err)
@@ -117,7 +117,7 @@ function finish(data) {
     if (opts.output) {
         fs.writeFile(opts.output, data, function(err) {
             if (err)
-                fatal(err.message);
+	        fatal(err.message);
             process.exit(0);
         });
     } else {

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
 -->
 <html lang="en">
 <head>
-    <title translatable="yes">Cockpit Starter Kit</title>
+    <title translate>Cockpit Starter Kit</title>
     <meta charset="utf-8">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Cockpit's test-static-code complains about `translatable`, so let's use
the correct attribute to avoid spreading it further.