### PR TITLE
Show how to run the release in GitHub workflow

### DIFF
--- a/.github/workflows/release.yml.disabled
+++ b/.github/workflows/release.yml.disabled
@@ -1,0 +1,35 @@
+name: release
+on:
+  push:
+    tags:
+      # this is a glob, not a regexp
+      - '[0-9]*'
+jobs:
+  cockpituous:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/cockpit/release
+    steps:
+      - name: Set up configuration and secrets
+        run: |
+          # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
+          export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+
+          # secrets come from https://github.com/organizations/ORGNAME/settings/secrets or https://github.com/OWNER/REPO/settings/secrets
+          # see https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets
+          echo '${{ secrets.SSH_KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+          echo '${{ secrets.FEDPKG_SSH_PUBLIC }}' > ~/.ssh/id_rsa.pub
+          echo '${{ secrets.FEDPKG_SSH_PRIVATE }}' > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          # FIXME: Set your Fedora user account name here
+          echo 'yourfedorauser' > ~/.config/bodhi-user
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+          echo '${{ secrets.COPR_TOKEN }}' > ~/.config/copr
+          echo '${{ secrets.FEDORA_PASSWORD }}' > ~/.fedora-password
+
+      - name: Run cockpituous
+        run: |
+          # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
+          export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+          cd /build
+          release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) ./cockpituous-release

--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ that.  [Cockpituous release](https://github.com/cockpit-project/cockpituous/tree
 aims to fully automate project releases to GitHub, Fedora, Ubuntu, COPR, Docker
 Hub, and other places. The intention is that the only manual step for releasing
 a project is to create a signed tag for the version number; pushing the tag
-then triggers a GitHub webhook that calls a set of release scripts (on
-Cockpit's CI infrastructure).
+then triggers a [GitHub action](https://github.com/features/actions) that calls a set of release scripts.
 
-starter-kit includes an example [cockpitous release script](./cockpituous-release)
-that builds an upstream release tarball and source RPM. Please see the above
-cockpituous documentation for details.
+starter-kit includes an example [cockpitous release script](./cockpituous-release),
+with detailed comments how to use it. There is also an
+[example GitHub release action](.github/workflows/release.yml.disabled) to set
+up secrets and run cockpituous.
 
 # Further reading
 

--- a/cockpituous-release
+++ b/cockpituous-release
@@ -1,4 +1,4 @@
-# This is a script run to release welder-web through Cockpituous:
+# This is a script run to release this project through Cockpituous:
 # https://github.com/cockpit-project/cockpituous/tree/master/release
 
 # Anything that start with 'job' may run in a way that it SIGSTOP's
@@ -6,6 +6,9 @@
 # order to complete its work.
 #
 # Check cockpituous documentation for available release targets.
+#
+# This gets run through a GitHub action: enable and adjust
+# .github/workflows/release.yml.disabled once you are ready.
 
 RELEASE_SOURCE="_release/source"
 RELEASE_SPEC="cockpit-starter-kit.spec"
@@ -14,18 +17,21 @@ RELEASE_SRPM="_release/srpm"
 job release-source
 job release-srpm -V
 
-# Once you have a Fedora package and add the https://pagure.io/user/cockpit
-# user to your project's maintainers, you can also upload to Fedora automatically:
+# Once you have a Fedora package, can upload to Fedora automatically: Provide the
+# secrets in .github/workflows/release.yml on GitHub, and enable the following:
 
-## Authenticate for pushing into Fedora dist-git (works in Cockpituous release container)
-# cat ~/.fedora-password | kinit cockpit@FEDORAPROJECT.ORG
+## Authenticate for pushing into Fedora dist-git
+# cat ~/.fedora-password | kinit yourfedorauser@FEDORAPROJECT.ORG
 ## Do fedora builds for the tag, using tarball
 # job release-koji -k master
-# job release-koji f29
-# job release-bodhi F29
+# job release-koji f33
+# job release-bodhi F33
 
 # These are likely the first of your release targets; but run them after Fedora uploads,
 # so that failures there will fail the release early, before publishing on GitHub
 
+# this needs no explicit secrets, just the GitHub action provided default one
 # job release-github
+
+# This needs secrets.COPR_TOKEN in .github/workflows/release.yml
 # job release-copr @myorg/myrepo


### PR DESCRIPTION
Enter the new world of GitHub actions [1]/GitLab pipelines [2]. This
simplifies our end of the infrastructure considerably:

* No need any more to set up webhooks, all the relevant configuration
  is right in the workflow file.

* Does not need any infrastructure on our side any more, and thus works
  for third-party projects. They just need to set up their own secrets.

* GitHub automatically provides a temporary `GITHUB_TOKEN` with
  sufficient write access to the project to publish a release, so we
  don't need to carry around that secret. Thus if your project only
  releases to GitHub, there is zero secrets management.

Also adjust cockpituous-release a bit (update Fedora version, fix
project name copy-pasta), point to the action workflow and necessary
secrets.