### PR TITLE
Run integration tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,31 @@
 dist: focal
-sudo: false
-language: node_js
-node_js:
-  - "lts/*"
+sudo: true
+language: minimal
 addons:
   apt:
     packages:
+      - appstream-util
+      - chromium-browser
+      - curl
+      - git
+      - libvirt-daemon-system
+      - npm
+      - python3-libvirt
+      - qemu-kvm
+      - qemu-utils
+      - rpm
       - sassc
+env:
+  - TEST_OS=fedora-33
+  - TEST_OS=centos-8-stream
 script:
-  - make
+  # HACK: /dev/kvm is root:kvm 0660 by default
+  - sudo chmod 666 /dev/kvm
+
+  # test PO template generation
   - make po/starter-kit.pot
+
+  # FIXME: build rpm inside VM; no installed rpms on Travis Ubuntu environment
+  - sed -i '/^BuildRequires:/d' *.spec.in
+
+  - TEST_JOBS=$(nproc) make check

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ po/POTFILES.html.in:
 	mkdir -p $(dir $@)
 	find src -name '*.html' > $@
 
-po/$(PACKAGE_NAME).html.pot: po/POTFILES.html.in
+po/$(PACKAGE_NAME).html.pot: po/POTFILES.html.in $(NODE_MODULES_TEST)
 	po/html2po -f $^ -o $@
 
-po/$(PACKAGE_NAME).manifest.pot:
+po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST)
 	po/manifest2po src/manifest.json -o $@
 
 po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ You can also run the test against a different Cockpit image, for example:
 
     TEST_OS=fedora-32 make check
 
+These tests can be run in [Travis CI](https://travis-ci.com/). The included
+[travis.yml](./.travis.yml) runs the integration tests for two operating
+systems (Fedora and CentOS 8). Note that if/once your project grows bigger, or
+gets frequent changes, you likely need to move to a paid account, or different
+infrastructure with more capacity. Talk to the
+[Cockpit developers](https://cockpit-project.org/) if you are interested in that.
+
 # Customizing
 
 After cloning the Starter Kit you should rename the files, package names, and


### PR DESCRIPTION
Travis now offers /dev/kvm, and its machines are powerful enough to run our browser integration tests, at least for small projects.