### PR TITLE
Bump test/common dependency to 233

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 230; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 233; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -10,6 +10,3 @@ if type firewall-cmd >/dev/null 2>&1; then
     firewall-cmd --add-service=cockpit --permanent
 fi
 systemctl enable cockpit.socket
-
-# HACK: See https://github.com/cockpit-project/cockpit/issues/14133
-mkdir -p /usr/share/cockpit/packagekit


### PR DESCRIPTION
This gets rid of the hack for
<https://github.com/cockpit-project/cockpit/issues/14133>.