### PR TITLE
workflows: Update release container registry

### DIFF
--- a/.github/workflows/release.yml.disabled
+++ b/.github/workflows/release.yml.disabled
@@ -8,7 +8,7 @@ jobs:
   cockpituous:
     runs-on: ubuntu-latest
     container:
-      image: docker.io/cockpit/release
+      image: ghcr.io/cockpit-project/release
     steps:
       - name: Set up configuration and secrets
         run: |


### PR DESCRIPTION
With [1] the release container moved from dockerhub to GitHub's
container registry, as we both build and use it from GitHub. This avoids
running into docker.io pull limits.

[1] https://github.com/cockpit-project/cockpituous/pull/353