### PR TITLE
webpack: Show sassc errors

### DIFF
--- a/src/lib/sassc-loader.js
+++ b/src/lib/sassc-loader.js
@@ -12,7 +12,7 @@ module.exports = function() {
     childProcess.execFileSync(
         'sassc',
         ['--load-path=node_modules', '--style=compressed', '--sourcemap', this.resource, out],
-        { stdio: ['pipe', 'stdio', 'stdio'] });
+        { stdio: ['pipe', 'inherit', 'inherit'] });
 
     const css = fs.readFileSync(out, 'utf8');
     const cssmap = fs.readFileSync(out + ".map", 'utf8');


### PR DESCRIPTION
`stdio` is not a valid value for the `stdio` option. This led to sassc's
stdout/err to be hidden, and thus it did not show error messages.

[1] https://nodejs.org/api/child_process.html#child_process_options_stdio