### PR TITLE
spec: Add BuildRequires: make

### DIFF
--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -6,7 +6,8 @@ License: LGPLv2+
 
 Source: cockpit-starter-kit-%{version}.tar.gz
 BuildArch: noarch
-BuildRequires:  libappstream-glib
+BuildRequires: make
+BuildRequires: libappstream-glib
 
 Requires: cockpit-system
 


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/Remove_make_from_BuildRoot