### PR TITLE
cockpit-po-plugin: Fix crash with plural forms

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -12,6 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1\n"
 
 #: src/index.html:20
 msgid "Cockpit Starter Kit"

--- a/src/lib/cockpit-po-plugin.js
+++ b/src/lib/cockpit-po-plugin.js
@@ -59,7 +59,7 @@ module.exports = class {
 
             // We know the brace in is the location to insert our function
             if (plurals) {
-                pos = output.indexOf('{', 1);
+                const pos = output.indexOf('{', 1);
                 output = output.substr(0, pos + 1) + "'plural-forms':" + String(plurals) + "," + output.substr(pos + 1);
             }
 


### PR DESCRIPTION
Declare the `pos` variable. Fixes regression introduced in commit
7f6ef51c12a7.

Add plural forms to German translations to exercise this code path.