### PR TITLE
Drop unused version numbers from package.json and manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "starter-kit",
-  "version": "0.1.0",
   "description": "Scaffolding for a cockpit module",
   "main": "index.js",
   "repository": "git@github.com:cockpit/starter-kit.git",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,4 @@
 {
-    "version": "0.1",
     "requires": {
         "cockpit": "137"
     },


### PR DESCRIPTION
This field was introduced in
https://github.com/cockpit-project/cockpit/pull/4964 as "purely
informational for now", and isn't even parsed by cockpit.

package.json's version would only be relevant for publishing NPM
modules, but cockpit pages are not that.

Neither starter-kit itself nor our derived projects like cockpit-podman
or cockpit-composer have ever maintained these two fields, so just get
rid of them.

This makes the git tag the single source of truth for the version
number.

Fixes #200