### PR TITLE
Bump cockpit test API to 239

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 233; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 239; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/test/check-application
+++ b/test/check-application
@@ -47,7 +47,7 @@ class TestApplication(testlib.MachineCase):
         b.expect_load()
         # HACK: work around language switching in Chrome not working in current session (Cockpit issue #8160)
         b.reload(ignore_cache=True)
-        b.wait_present("#content")
+        b.wait_visible("#content")
         # menu label (from manifest) should be translated
         b.wait_text("#host-apps a[href='/starter-kit']", "Bausatz")
 


### PR DESCRIPTION
Replace the deprecated wait_present().

 - [x] Fix run-tests regression in cockpit: https://github.com/cockpit-project/cockpit/pull/15428
 - [x] Release cockpit 239

This needs to wait, I just want to not forget about it.