### PR TITLE
Move default TEST_OS to centos-8-stream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' package.json)
 VERSION := $(shell T=$$(git describe 2>/dev/null) || T=1; echo $$T | tr '-' '.')
 ifeq ($(TEST_OS),)
-TEST_OS = centos-7
+TEST_OS = centos-8-stream
 endif
 export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Rules configuration can be found in the `.eslintrc.json` file.
 # Running tests locally
 
 Run `make check` to build an RPM, install it into a standard Cockpit test VM
-(centos-7 by default), and run the test/check-application integration test on
+(centos-8-stream by default), and run the test/check-application integration test on
 it. This uses Cockpit's Chrome DevTools Protocol based browser tests, through a
 Python API abstraction. Note that this API is not guaranteed to be stable, so
 if you run into failures and don't want to adjust tests, consider checking out
@@ -74,11 +74,11 @@ After the test VM is prepared, you can manually run the test without rebuilding
 the VM, possibly with extra options for tracing and halting on test failures
 (for interactive debugging):
 
-    TEST_OS=centos-7 test/check-application -tvs
+    TEST_OS=centos-8-stream test/check-application -tvs
 
 You can also run the test against a different Cockpit image, for example:
 
-    TEST_OS=fedora-32 make check
+    TEST_OS=fedora-34 make check
 
 # Running tests in CI
 


### PR DESCRIPTION
We don't run centos-7 in CI any more, and thus can't guarantee that it
works.