### PR TITLE
Move to webpack 5

### DIFF
--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -24,7 +24,7 @@ Cockpit Starter Kit Example Module
 appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 
 # drop source maps, they are large and just for debugging
-find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs rm --verbose
+find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs --no-run-if-empty rm --verbose
 
 %files
 %{_datadir}/cockpit/*

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "compression-webpack-plugin": "^6.0.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^4.3.0",
+    "css-minimizer-webpack-plugin": "^1.3.0",
     "eslint": "^7.10.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-config-standard-react": "^9.2.0",
@@ -35,15 +36,13 @@
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",
     "mini-css-extract-plugin": "^0.11.0",
-    "optimize-css-assets-webpack-plugin": "^5.0.3",
     "po2json": "^1.0.0-alpha",
     "qunit": "^2.9.3",
     "sizzle": "^2.3.3",
     "stdio": "^2.1.0",
-    "string-replace-loader": "^2.3.0",
-    "terser-webpack-plugin": "^2.0.1",
-    "webpack": "^4.35.3",
-    "webpack-cli": "^3.3.5"
+    "string-replace-loader": "^3.0.0",
+    "webpack": "^5.31.0",
+    "webpack-cli": "^4.6.0"
   },
   "dependencies": {
     "@patternfly/patternfly": "4.96.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,7 @@ const childProcess = require('child_process');
 
 const copy = require("copy-webpack-plugin");
 const extract = require("mini-css-extract-plugin");
-const TerserJSPlugin = require('terser-webpack-plugin');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CompressionPlugin = require("compression-webpack-plugin");
 const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
 
@@ -87,7 +86,7 @@ module.exports = {
 
     optimization: {
         minimize: production,
-        minimizer: [new TerserJSPlugin({}), new OptimizeCSSAssetsPlugin({})],
+        minimizer: [`...`, new CssMinimizerPlugin()],
     },
 
     module: {


### PR DESCRIPTION
We don't need to explicitly mention TerserJSPlugin any more (from commit
6b8611), as webpack 5 can now extend the `minimizer:` list with the
special `...` syntax.

This gets rid of several `npm install` warnings:

    deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
    deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
    deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
    deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.

as well as 10 MB of node_modules.

 - [x] fix cockpit-po-plugin to not touch Compilation.assets after sealing: https://github.com/cockpit-project/cockpit/pull/15668
 - [x] go through https://webpack.js.org/migrate/5/ and clean up obsolete stuff