### PR TITLE
Build and ship LICENSE file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ dist-gzip: $(TARFILE)
 # we don't ship node_modules for license and compactness reasons; we ship a
 # pre-built dist/ (so it's not necessary) and ship packge-lock.json (so that
 # node_modules/ can be reconstructed if necessary)
-$(TARFILE): NODE_ENV=production
+$(TARFILE): export NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
 	if type appstream-util >/dev/null 2>&1; then appstream-util validate-relax --nonet *.metainfo.xml; fi
 	mv node_modules node_modules.release

--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -27,6 +27,8 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs --no-run-if-empty rm --verbose
 
 %files
+%doc README.md
+%license LICENSE dist/index.js.LICENSE.txt
 %{_datadir}/cockpit/*
 %{_datadir}/metainfo/*
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sizzle": "^2.3.3",
     "stdio": "^2.1.0",
     "string-replace-loader": "^3.0.0",
+    "terser-webpack-plugin": "^2.0.1",
     "webpack": "^5.31.0",
     "webpack-cli": "^4.6.0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const childProcess = require('child_process');
 
 const copy = require("copy-webpack-plugin");
 const extract = require("mini-css-extract-plugin");
+const TerserJSPlugin = require('terser-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CompressionPlugin = require("compression-webpack-plugin");
 const ESLintPlugin = require('eslint-webpack-plugin');
@@ -69,7 +70,7 @@ module.exports = {
 
     optimization: {
         minimize: production,
-        minimizer: [`...`, new CssMinimizerPlugin()],
+        minimizer: [new TerserJSPlugin(), new CssMinimizerPlugin()],
     },
 
     module: {


### PR DESCRIPTION
Bring back terser-webpack-plugin from commit c52136c051448 and re-enable
it. It builds the autogenerated dist/index.js.LICENSE.txt which is quite
important for shipping distribution packages -- c-{podman,machines} both
do this.

Backport https://github.com/cockpit-project/cockpit-podman/commit/95021c336ed
to make sure that the webpack for the release tarball is *actually*
built in production mode.