### PR TITLE
Bump cockpit test/common and lib to 242

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,14 +147,14 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 239; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 242; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 238; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 242; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -5,6 +5,7 @@ require:
   - cockpit-ws
   - cockpit-system
   - git
+  - glibc-langpack-de
   - libvirt-python3
   - make
   - npm


### PR DESCRIPTION
https://github.com/martinpitt/cockpit/commit/731fdf82c0 fixed the
deprecation warning in cockpit-po-plugin:

> node:37175) [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning:
> Compilation.assets will be frozen in future, all modifications are
> deprecated.
> BREAKING CHANGE: No more changes should happen to Compilation.assets
> after sealing the Compilation.

 - [x] Adjust tests for cockpit 242: PR #449