### PR TITLE
packit: Build in development mode

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -5,10 +5,15 @@
 specfile_path: cockpit-starter-kit.spec
 actions:
   post-upstream-clone: make cockpit-starter-kit.spec
-  # reduce memory consumption of webpack in sandcastle container
+  # build in development mode; production mode uses too much memory for limited
+  # sandcastle containers; also reduce memory consumption of webpack
   # https://github.com/packit/sandcastle/pull/92
   # https://medium.com/the-node-js-collection/node-js-memory-management-in-container-environments-7eb8409a74e8
-  create-archive: make NODE_OPTIONS=--max-old-space-size=500 dist-gzip
+  create-archive:
+    - make NODE_ENV=development NODE_OPTIONS=--max-old-space-size=500
+    # dummy LICENSE.txt, as terser did not run
+    - touch dist/index.js.LICENSE.txt
+    - make dist-gzip
   # starter-kit.git has no release tags; your project can drop this once you have a release
   get-current-version: make print-version
 jobs:


### PR DESCRIPTION
With recent NPM/sandcastle versions, production mode and its additional
optimizations don't fit any more into the 768 MB RAM of sandcastle
containers. Build in development mode, which skips the optimization
steps.

Taken from https://github.com/cockpit-project/cockpit-podman/commit/7000b4460e6ac

------


In #462 we got packit srpm build failures. Investigating them here:
```
(node:209) [DEP_WEBPACK_COMPILATION_OPTIMIZE_CHUNK_ASSETS] DeprecationWarning: optimizeChunkAssets is deprecated (use Compilation.hooks.processAssets instead and use one of Compilation.PROCESS_ASSETS_STAGE_* as stage option)
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:209) [DEP_WEBPACK_COMPILATION_CACHE] DeprecationWarning: Compilation.cache was removed in favor of Compilation.getCache()
ERROR in index.js from Terser
Error: Call retries were exceeded
    at ChildProcessWorker.initialize (/sandcastle/quay-io-packit-sandcastle-prod-20210530-045108331354/node_modules/terser-webpack-plugin/node_modules/jest-worker/build/workers/ChildProcessWorker.js:191:21)
    at ChildProcessWorker._onExit (/sandcastle/quay-io-packit-sandcastle-prod-20210530-045108331354/node_modules/terser-webpack-plugin/node_modules/jest-worker/build/workers/ChildProcessWorker.js:268:12)
    at ChildProcess.emit (events.js:315:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:277:12)
```