### PR TITLE
test: Fix host name lookup

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -25,7 +25,7 @@ class TestApplication(testlib.MachineCase):
         b.wait_text(".pf-c-card__title", "Starter Kit")
 
         # verify expected host name
-        hostname = m.execute("hostname").strip()
+        hostname = m.execute("cat /etc/hostname").strip()
         b.wait_in_text(".pf-c-alert__title", "Running on " + hostname)
 
         # change current hostname


### PR DESCRIPTION
Our code reads /etc/hostname. Do the same in the test, as the runtime
sethostname(2) (set by hostnamed) and static host name may be different.