### PR TITLE
Rebuild webpack during RPM build, move to `make dist` xz tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *~
 *.retry
-*.tar.gz
+*.tar.xz
 *.rpm
 node_modules/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ update-po: po/$(PACKAGE_NAME).pot
 	sed -e 's/%{VERSION}/$(VERSION)/g' $< > $@
 
 $(WEBPACK_TEST): $(NODE_MODULES_TEST) $(LIB_TEST) $(shell find src/ -type f) package.json webpack.config.js
-	NODE_ENV=$(NODE_ENV) npm run build
+	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack
 
 watch:
-	NODE_ENV=$(NODE_ENV) npm run watch
+	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack --watch
 
 clean:
 	rm -rf dist/

--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,11 @@ dist-gzip: $(TARFILE)
 $(TARFILE): export NODE_ENV=production
 $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
 	if type appstream-util >/dev/null 2>&1; then appstream-util validate-relax --nonet *.metainfo.xml; fi
-	mv node_modules node_modules.release
 	touch -r package.json $(NODE_MODULES_TEST)
 	touch dist/*
 	tar czf cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
-		--exclude cockpit-$(PACKAGE_NAME).spec.in \
+		--exclude cockpit-$(PACKAGE_NAME).spec.in --exclude node_modules \
 		$$(git ls-files) $(LIB_TEST) src/lib/patternfly/*.scss package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
-	mv node_modules.release node_modules
 
 srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ $(NODE_CACHE): $(NODE_MODULES_TEST)
 
 node-cache: $(NODE_CACHE)
 
-srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
+srpm: $(TARFILE) $(NODE_CACHE) cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \
 	  --define "_sourcedir `pwd`" \
 	  --define "_srcrpmdir `pwd`" \
@@ -108,7 +108,7 @@ srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 
 rpm: $(RPMFILE)
 
-$(RPMFILE): $(TARFILE) cockpit-$(PACKAGE_NAME).spec
+$(RPMFILE): $(TARFILE) $(NODE_CACHE) cockpit-$(PACKAGE_NAME).spec
 	mkdir -p "`pwd`/output"
 	mkdir -p "`pwd`/rpmbuild"
 	rpmbuild -bb \

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
 	touch dist/*
 	tar czf cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude cockpit-$(PACKAGE_NAME).spec.in --exclude node_modules \
-		$$(git ls-files) $(LIB_TEST) src/lib/patternfly/*.scss package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
+		$$(git ls-files) $(LIB_TEST) src/lib package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
 
 srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifeq ($(TEST_OS),)
 TEST_OS = centos-8-stream
 endif
 export TEST_OS
-TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
+TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.xz
 NODE_CACHE=cockpit-$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q cockpit-$(PACKAGE_NAME).spec.in).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
@@ -79,7 +79,7 @@ devel-install: $(WEBPACK_TEST)
 print-version:
 	@echo "$(VERSION)"
 
-dist-gzip: $(TARFILE)
+dist: $(TARFILE)
 	@ls -1 $(TARFILE)
 
 # when building a distribution tarball, call webpack with a 'production' environment
@@ -91,7 +91,7 @@ $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
 	if type appstream-util >/dev/null 2>&1; then appstream-util validate-relax --nonet *.metainfo.xml; fi
 	touch -r package.json $(NODE_MODULES_TEST)
 	touch dist/*
-	tar czf cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
+	tar --xz -cf cockpit-$(PACKAGE_NAME)-$(VERSION).tar.xz --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude cockpit-$(PACKAGE_NAME).spec.in --exclude node_modules \
 		$$(git ls-files) $(LIB_TEST) src/lib package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
 
@@ -170,4 +170,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install print-version dist-gzip node-cache srpm rpm check vm update-po
+.PHONY: all clean install devel-install print-version dist node-cache srpm rpm check vm update-po

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ TEST_OS = centos-8-stream
 endif
 export TEST_OS
 TARFILE=cockpit-$(PACKAGE_NAME)-$(VERSION).tar.gz
+NODE_CACHE=cockpit-$(PACKAGE_NAME)-node-$(VERSION).tar.xz
 RPMFILE=$(shell rpmspec -D"VERSION $(VERSION)" -q cockpit-$(PACKAGE_NAME).spec.in).rpm
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check if/when npm install ran
@@ -94,6 +95,11 @@ $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
 		--exclude cockpit-$(PACKAGE_NAME).spec.in --exclude node_modules \
 		$$(git ls-files) $(LIB_TEST) src/lib package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
 
+$(NODE_CACHE): $(NODE_MODULES_TEST)
+	tar --xz -cf $@ node_modules
+
+node-cache: $(NODE_CACHE)
+
 srpm: $(TARFILE) cockpit-$(PACKAGE_NAME).spec
 	rpmbuild -bs \
 	  --define "_sourcedir `pwd`" \
@@ -164,4 +170,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install print-version dist-gzip srpm rpm check vm update-po
+.PHONY: all clean install devel-install print-version dist-gzip node-cache srpm rpm check vm update-po

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make
 
 `make install` compiles and installs the package in `/usr/share/cockpit/`. The
 convenience targets `srpm` and `rpm` build the source and binary rpms,
-respectively. Both of these make use of the `dist-gzip` target, which is used
+respectively. Both of these make use of the `dist` target, which is used
 to generate the distribution tarball. In `production` mode, source files are
 automatically minified and compressed. Set `NODE_ENV=production` if you want to
 duplicate this behavior.

--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -4,8 +4,10 @@ Release: 1%{?dist}
 Summary: Cockpit Starter Kit Example Module
 License: LGPLv2+
 
-Source: cockpit-starter-kit-%{version}.tar.xz
+Source0: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/cockpit-starter-kit-%{version}.tar.xz
+Source1: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/cockpit-starter-kit-node-%{version}.tar.xz
 BuildArch: noarch
+BuildRequires:  nodejs
 BuildRequires: make
 BuildRequires: libappstream-glib
 
@@ -17,7 +19,13 @@ Requires: cockpit-system
 Cockpit Starter Kit Example Module
 
 %prep
-%setup -n cockpit-starter-kit
+%setup -q -n cockpit-starter-kit
+%setup -q -a 1 -n cockpit-starter-kit
+
+%build
+# ignore pre-built webpack in release tarball and rebuild it
+rm -rf dist
+NODE_ENV=production make
 
 %install
 %make_install

--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -4,7 +4,7 @@ Release: 1%{?dist}
 Summary: Cockpit Starter Kit Example Module
 License: LGPLv2+
 
-Source: cockpit-starter-kit-%{version}.tar.gz
+Source: cockpit-starter-kit-%{version}.tar.xz
 BuildArch: noarch
 BuildRequires: make
 BuildRequires: libappstream-glib

--- a/packit.yaml
+++ b/packit.yaml
@@ -4,7 +4,12 @@
 
 specfile_path: cockpit-starter-kit.spec
 actions:
-  post-upstream-clone: make cockpit-starter-kit.spec
+  post-upstream-clone:
+  post-upstream-clone:
+    - make cockpit-starter-kit.spec
+    # replace Source1 manually, as create-archive: can't handle multiple tarballs
+    - make node-cache
+    - sh -c 'sed -i "/^Source1:/ s/https:.*/$(ls *-node*.tar.xz)/" cockpit-*.spec'
   # build in development mode; production mode uses too much memory for limited
   # sandcastle containers; also reduce memory consumption of webpack
   # https://github.com/packit/sandcastle/pull/92

--- a/packit.yaml
+++ b/packit.yaml
@@ -13,7 +13,7 @@ actions:
     - make NODE_ENV=development NODE_OPTIONS=--max-old-space-size=500
     # dummy LICENSE.txt, as terser did not run
     - touch dist/index.js.LICENSE.txt.gz
-    - make dist-gzip
+    - make dist
   # starter-kit.git has no release tags; your project can drop this once you have a release
   get-current-version: make print-version
 jobs:


### PR DESCRIPTION
This is necessary to comply with Fedora's packaging policy:
https://docs.fedoraproject.org/en-US/packaging-guidelines/JavaScript/
    
Include the node cache in the source rpm, unpack it into the main source
dir, and force a webpack rebuild in `%build`.

-----

Ported from https://github.com/skobyda/cockpit-certificates/pull/65 . It's generally a nice life insurance to release the `node_modules/` together with the software -- then distros can still patch old versions easily.