### PR TITLE
.gitignore: add tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test/images/
 src/lib/
 *.pot
 POTFILES*
+tmp/


### PR DESCRIPTION
Include to tmp/ directory to be ignored, it usually contains temporary
vm-run images.