### PR TITLE
Makefile: Avoid cockpit-po-plugin.js hardlink in dist tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ $(TARFILE): $(WEBPACK_TEST) cockpit-$(PACKAGE_NAME).spec
 	touch dist/*
 	tar --xz -cf cockpit-$(PACKAGE_NAME)-$(VERSION).tar.xz --transform 's,^,cockpit-$(PACKAGE_NAME)/,' \
 		--exclude cockpit-$(PACKAGE_NAME).spec.in --exclude node_modules \
-		$$(git ls-files) $(LIB_TEST) src/lib package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
+		$$(git ls-files) src/lib package-lock.json cockpit-$(PACKAGE_NAME).spec dist/
 
 $(NODE_CACHE): $(NODE_MODULES_TEST)
 	tar --xz -cf $@ node_modules


### PR DESCRIPTION
Drop the redundant `$(LIB_TEST)` from the tar file list; it is
src/lib/cockpit-po-plugin.js, which is already contained in src/lib, and
tar turns that into an unsightly hardlink.

See https://github.com/cockpit-project/cockpit-machines/issues/379

----

Reproducer:
```
❱❱❱ make dist; tar tvf cockpit-starter-kit-1.tar.xz | grep po-plugin
-rw-r--r-- martin/martin  5261 2021-09-16 08:50 cockpit-starter-kit/src/lib/cockpit-po-plugin.js
hrw-r--r-- martin/martin     0 2021-09-16 08:50 cockpit-starter-kit/src/lib/cockpit-po-plugin.js link to cockpit-starter-kit/src/lib/cockpit-po-plugin.js
```