### PR TITLE
webpack: Avoid md4 hash for OpenSSL 3 compatibility

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,11 @@ const CompressionPlugin = require("compression-webpack-plugin");
 const ESLintPlugin = require('eslint-webpack-plugin');
 const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
 
+// HACK: OpenSSL 3 does not support md4 any more, but webpack hardcodes it all over the place: https://github.com/webpack/webpack/issues/13572
+const crypto = require("crypto");
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+
 const webpack = require("webpack");
 
 const nodedir = path.resolve((process.env.SRCDIR || __dirname), "node_modules");


### PR DESCRIPTION
CentOS/RHEL 9 switched to OpenSSL 3, which does not support the `md4`
hash any more. webpack 5 hardcodes that in no less than 21 places, so
monkey-patch `crypto.createHash()` to substitute sha256 for md4.

Hack to work around https://github.com/webpack/webpack/issues/13572