### PR TITLE
eslint: Enable no-var rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
                 "ignoredNodes": [ "JSXAttribute" ]
             }],
         "newline-per-chained-call": ["error", { "ignoreChainWithDepth": 2 }],
+        "no-var": "error",
         "lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
         "prefer-promise-reject-errors": ["error", { "allowEmptyReject": true }],
         "react/jsx-indent": ["error", 4],


### PR DESCRIPTION
`var` has broken/unexpected scoping in JavaScript, and can lead to
subtle errors. It's preferable and safer to use `const` whenever
possible, and `let` where necessary.

There are no usages of `var` in starter-kit right now, so just enable
the rule to ensure that it stays that way.

----

Tested with adding a ` var x = "foo"` to the code, it then fails to build with
```
ERROR in 
/var/home/martin/upstream/starter-kit/src/app.jsx
  26:1  error  Unexpected var, use let or const instead  no-var
```

See also https://github.com/cockpit-project/cockpit/pull/16369