### PR TITLE
webpack: Use default resolve path for npm 7 compatibility

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,8 +15,6 @@ crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sh
 
 const webpack = require("webpack");
 
-const nodedir = path.resolve((process.env.SRCDIR || __dirname), "node_modules");
-
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
 
@@ -44,11 +42,11 @@ if (production) {
 module.exports = {
     mode: production ? 'production' : 'development',
     resolve: {
-        modules: [ nodedir, path.resolve(__dirname, 'src/lib') ],
-        alias: { 'font-awesome': path.resolve(nodedir, 'font-awesome-sass/assets/stylesheets') },
+        modules: [ "node_modules", path.resolve(__dirname, 'src/lib') ],
+        alias: { 'font-awesome': 'font-awesome-sass/assets/stylesheets' },
     },
     resolveLoader: {
-        modules: [ nodedir, path.resolve(__dirname, 'src/lib') ],
+        modules: [ "node_modules", path.resolve(__dirname, 'src/lib') ],
     },
     watchOptions: {
         ignored: /node_modules/,


### PR DESCRIPTION
npm 7 changed how it resolves dependencies, and starter-kit fails to
build with lots of unresolved peer dependencies of PatternFly.

With an absolute path, `resolve.modules` will only look in that
directory; the default is a relative path "node_modules" that just
works [1]. Use that default, as we don't use `$SRCDIR` in this project
anyway.

[1] https://webpack.js.org/configuration/resolve/#resolvemodules

----

I tested this in a Fedora 35 toolbox. Without this, it fails due to tons of

> ERROR in ./node_modules/@patternfly/react-core/dist/esm/components/AboutModal/AboutModalBoxCloseButton.js 6:0-74
Module not found: Error: Can't resolve '@patternfly/react-icons/dist/esm/icons/times-icon' in '/var/home/martin/upstream/starter-kit/node_modules/@patternfly/react-core/dist/esm/components/AboutModal'
