### PR TITLE
po: Pick up also strings with specified context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ LINGUAS=$(basename $(notdir $(wildcard po/*.po)))
 
 po/$(PACKAGE_NAME).js.pot:
 	xgettext --default-domain=cockpit --output=$@ --language=C --keyword= \
-		--keyword=_:1,1t --keyword=_:1c,2,1t --keyword=C_:1c,2 \
+		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \


### PR DESCRIPTION
Strings like `_("Context", "String to translate")` were not picked up.

Taken from https://github.com/cockpit-project/cockpit/commit/ba95d680d2

----

This currently makes no practical difference (generated POT is identical except for the timestamp), but let's be correct to avoid surprises for app authors.