### PR TITLE
test: Adjust language changing for Cockpit 258

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -34,12 +34,17 @@ class TestApplication(testlib.MachineCase):
         b.wait_in_text(".pf-c-alert__title", "Running on new-" + hostname)
 
         # change language to German
+        # the menu and dialog changed several times
         b.switch_to_top()
-        b.click("#navbar-dropdown")
-        b.click(".display-language-menu a")
-        b.wait_popup('display-language')
-        # the dialog changed several times
         cockpit_version = float(m.execute("cockpit-bridge --version | sed -n '/Version:/ s/^.*: //p'").strip())
+        if cockpit_version >= 258:
+            b.click("#toggle-menu")
+            b.click(".display-language-menu")
+            b.wait_popup('display-language-modal')
+        else:
+            b.click("#navbar-dropdown")
+            b.click(".display-language-menu a")
+            b.wait_popup('display-language')
         if cockpit_version >= 242:
             b.click("#display-language-modal [data-value='de-de'] button")
             b.click("#display-language-modal button.pf-m-primary")


### PR DESCRIPTION
That version rewrote the Shell in React, the ids/classes changed.

---

rawhide tests [started to fail](http://artifacts.dev.testing-farm.io/d6bf2dae-5ae3-4d5d-a6b5-c195c1491c78/), and soon will the F35/34 ones.
