### PR TITLE
package.json: Update copy-webpack-plugin to major version 10

### DIFF
--- a/cockpit-starter-kit.spec.in
+++ b/cockpit-starter-kit.spec.in
@@ -7,7 +7,7 @@ License: LGPLv2+
 Source0: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/%{name}-%{version}.tar.xz
 Source1: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/%{name}-node-%{version}.tar.xz
 BuildArch: noarch
-BuildRequires:  nodejs
+BuildRequires: nodejs >= 1:12
 BuildRequires: make
 BuildRequires: libappstream-glib
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-loader": "^8.0.6",
     "chrome-remote-interface": "^0.31.0",
     "compression-webpack-plugin": "^9.0.0",
-    "copy-webpack-plugin": "^9.0.0",
+    "copy-webpack-plugin": "^10.0.0",
     "css-loader": "^6.5.0",
     "css-minimizer-webpack-plugin": "^3.0.1",
     "eslint": "^7.10.0",


### PR DESCRIPTION
This is not compatible with the EOL node.js 10 any more, so bump the
build requirement.

---

This most likely doesn't actually work on CentOS 8, as centos-rpmbuild doesn't auto-enable module streams. But let's at least get a log.