### PR TITLE
webpack: Drop obsolete md4 hash hack

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "stdio": "^2.1.0",
     "string-replace-loader": "^3.0.0",
     "terser-webpack-plugin": "^5.1.4",
-    "webpack": "^5.31.0",
-    "webpack-cli": "^4.6.0"
+    "webpack": "^5.54.0",
+    "webpack-cli": "^4.9.1"
   },
   "dependencies": {
     "@patternfly/patternfly": "4.159.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,6 @@ const CompressionPlugin = require("compression-webpack-plugin");
 const ESLintPlugin = require('eslint-webpack-plugin');
 const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
 
-// HACK: OpenSSL 3 does not support md4 any more, but webpack hardcodes it all over the place: https://github.com/webpack/webpack/issues/13572
-const crypto = require("crypto");
-const crypto_orig_createHash = crypto.createHash;
-crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
-
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
 


### PR DESCRIPTION
webpack 5.54 solved this properly, bump the dependency.
