### PR TITLE
fmf: Work around missing /etc/nsswitch.conf in Fedora Rawhide

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -12,6 +12,9 @@ LOGS="$(pwd)/logs"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 
+# HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2033020
+dnf update -y pam || true
+
 # install firefox (available everywhere in Fedora and RHEL)
 # we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
 dnf install --disablerepo=fedora-cisco-openh264 -y firefox


### PR DESCRIPTION
Upgrading glibc in Rawhide now (semi-intentionally) removes
/etc/nsswitch.conf, but does not enforce installing a new enough
pam/authselect to ensure that it gets re-added. This breaks resolving
"localhost".

Reported as https://bugzilla.redhat.com/show_bug.cgi?id=2033020

----

This is meant to fix the [rawhide failure](http://artifacts.dev.testing-farm.io/582db548-a6d3-4fa0-9432-6347cdd070ba/) that has plagued us for a few days:
```
Error: getaddrinfo ENOTFOUND localhost
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:71:26) {
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'localhost'
}
```
I can't reproduce this locally with `tmt run --until report provision --how virtual --image fedora-rawhide`.