### PR TITLE
Add ability to rsync artifacts to a remote machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ test/common:
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 253; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git e224a0296cd25a448d70810a4c114bac574b82dd; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ or
 
     $ make watch
 
+When developing against a virtual machine, webpack can also automatically upload
+the code changes by setting the `RSYNC` environment variable to
+the remote hostname.
+
+    $ RSYNC=c make watch
+
 # Running eslint
 
 Cockpit Starter Kit uses [ESLint](https://eslint.org/) to automatically check

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const path = require("path");
 
 const copy = require("copy-webpack-plugin");
@@ -7,9 +8,13 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CompressionPlugin = require("compression-webpack-plugin");
 const ESLintPlugin = require('eslint-webpack-plugin');
 const CockpitPoPlugin = require("./src/lib/cockpit-po-plugin");
+const CockpitRsyncPlugin = require("./src/lib/cockpit-rsync-plugin");
 
 /* A standard nodejs and webpack pattern */
 const production = process.env.NODE_ENV === 'production';
+
+// Obtain package name from package.json
+const packageJson = JSON.parse(fs.readFileSync('package.json'));
 
 // Non-JS files which are copied verbatim to dist/
 const copy_files = [
@@ -22,6 +27,7 @@ const plugins = [
     new extract({filename: "[name].css"}),
     new ESLintPlugin({ extensions: ["js", "jsx"] }),
     new CockpitPoPlugin(),
+    new CockpitRsyncPlugin({dest: packageJson.name}),
 ];
 
 /* Only minimize when in production mode */


### PR DESCRIPTION
Use the CockpitRsyncWebpack plugin to optionally rsync build code to a
remote machine, the destination is determined by looking at the
package.json's name field.