### PR TITLE
webpack: Fail on eslint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-webpack-plugin": "^2.5.3",
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",
-    "mini-css-extract-plugin": "^2.4.5",
+    "mini-css-extract-plugin": "~2.4.5",
     "po2json": "^1.0.0-alpha",
     "qunit": "^2.9.3",
     "sass": "^1.35.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,10 @@ const copy_files = [
 const plugins = [
     new copy({ patterns: copy_files }),
     new extract({filename: "[name].css"}),
-    new ESLintPlugin({ extensions: ["js", "jsx"] }),
+    new ESLintPlugin({
+        extensions: ["js", "jsx"],
+        failOnWarning: true,
+    }),
     new CockpitPoPlugin(),
     new CockpitRsyncPlugin({dest: packageJson.name}),
 ];


### PR DESCRIPTION
Ensures we don't merge code with eslint warnings.