### PR TITLE
Use image-customize --build to build/install distribution packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ dist/
 /.vagrant
 package-lock.json
 Test*FAIL*
-bots/
+/bots
 test/common/
 test/images/
 src/lib/

--- a/test/vm.install
+++ b/test/vm.install
@@ -1,6 +1,6 @@
 #!/bin/sh
-# image-customize script to enable cockpit in test VMs
-# The application RPM will be installed separately
+# image-customize script to prepare a bots VM for testing this application
+# The application package will be installed separately
 set -eu
 
 # don't force https:// (self-signed cert)


### PR DESCRIPTION
This centralizes/factorizes the rpm package builds, and builds
RPM packages in the VM instead of on the host, which is cleaner. It also
paves the way for supporting Debian and arch builds.

Drop the `make srpm` rule, as it's not very useful. Keep the `make rpm`
rule, as sometimes developers do this manually. This might be replaced
later on with another image-customize feature which copies the built rpm
out of the VM.

----

Depends on https://github.com/cockpit-project/bots/pull/2903