### PR TITLE
Bump up eslint-config-standard-react and add fix for the new warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
         "browser": true,
         "es6": true
     },
-    "extends": ["eslint:recommended", "standard", "standard-react"],
+    "extends": ["eslint:recommended", "standard", "standard-react", "plugin:react/recommended"],
     "parser": "@babel/eslint-parser",
     "parserOptions": {
         "ecmaVersion": "7",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "css-minimizer-webpack-plugin": "^3.0.1",
     "eslint": "^7.10.0",
     "eslint-config-standard": "^14.1.1",
-    "eslint-config-standard-react": "^9.2.0",
+    "eslint-config-standard-react": "^11.0.1",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
This started giving errors like:
  22:10  error  'Alert' is defined but never used      no-unused-vars

Use eslint-plugin-react to improve the JSX usage, not just to silence this error.