### PR TITLE
cockpituous: Update example koji/bodhi configs

### DIFF
--- a/cockpituous-release
+++ b/cockpituous-release
@@ -23,9 +23,9 @@ job release-srpm -V
 ## Authenticate for pushing into Fedora dist-git
 # cat ~/.fedora-password | kinit yourfedorauser@FEDORAPROJECT.ORG
 ## Do fedora builds for the tag, using tarball
-# job release-koji -k main
-# job release-koji f33
-# job release-bodhi F33
+# job release-koji rawhide
+# job release-koji f36
+# job release-bodhi F36
 
 # These are likely the first of your release targets; but run them after Fedora uploads,
 # so that failures there will fail the release early, before publishing on GitHub


### PR DESCRIPTION
We use the "rawhide" branch, "main" is just an alias (and less
descriptive). Also bump the release to Fedora 36.