### PR TITLE
Translate the AppStream metainfo file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/lib/
 *.pot
 POTFILES*
 tmp/
+/po/LINGUAS

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ po/$(PACKAGE_NAME).metainfo.pot: org.cockpit-project.$(PACKAGE_NAME).metainfo.xm
 po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot po/$(PACKAGE_NAME).metainfo.pot
 	msgcat --sort-output --output-file=$@ $^
 
+po/LINGUAS:
+	echo $(LINGUAS) | tr ' ' '\n' > $@
+
 # Update translations against current PO template
 update-po: po/$(PACKAGE_NAME).pot
 	for lang in $(LINGUAS); do \
@@ -68,12 +71,15 @@ watch:
 clean:
 	rm -rf dist/
 	rm -f $(SPEC)
+	rm -f po/LINGUAS
 
-install: $(WEBPACK_TEST)
+install: $(WEBPACK_TEST) po/LINGUAS
 	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	mkdir -p $(DESTDIR)/usr/share/metainfo/
-	cp org.cockpit-project.$(PACKAGE_NAME).metainfo.xml $(DESTDIR)/usr/share/metainfo/
+	msgfmt --xml -d po \
+		--template org.cockpit-project.$(PACKAGE_NAME).metainfo.xml \
+		-o $(DESTDIR)/usr/share/metainfo/org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
 
 # this requires a built source tree and avoids having to install anything system-wide
 devel-install: $(WEBPACK_TEST)

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,10 @@ po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST)
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST)
 	po/manifest2po src/manifest.json -o $@
 
-po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot
+po/$(PACKAGE_NAME).metainfo.pot: org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
+	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ $<
+
+po/$(PACKAGE_NAME).pot: po/$(PACKAGE_NAME).html.pot po/$(PACKAGE_NAME).js.pot po/$(PACKAGE_NAME).manifest.pot po/$(PACKAGE_NAME).metainfo.pot
 	msgcat --sort-output --output-file=$@ $^
 
 # Update translations against current PO template

--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -10,6 +10,10 @@ BuildArch: noarch
 BuildRequires:  nodejs
 BuildRequires: make
 BuildRequires: libappstream-glib
+BuildRequires: gettext
+%if 0%{?rhel} && 0%{?rhel} <= 8
+BuildRequires: libappstream-glib-devel
+%endif
 
 Requires: cockpit-system
 


### PR DESCRIPTION
Use the capabilities provided by newer versions of gettext (i.e. >= 0.19.6) to extract the translatable strings in AppStream metainfo files, and to merge the translations to create a translated file.

(Yes, the `LINGUAS` file with duplicated language names is a bit of meh, however it is the least of the issues, and only needs to be updated when a translation is added or removed.)

 - Requires https://github.com/cockpit-project/bots/pull/3049