### PR TITLE
spec: drop the `debug_package` %define

### DIFF
--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -13,8 +13,6 @@ BuildRequires: libappstream-glib
 
 Requires: cockpit-system
 
-%define debug_package %{nil}
-
 %description
 Cockpit Starter Kit Example Module
 


### PR DESCRIPTION
The generated RPM is noarch, so by definition has no binaries to extract
debug symbols from. Hence, drop the %define that makes RPM not error out
in case there are no debug symbols around (usually in archful binaries).