### PR TITLE
po: Update German translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: starter-kit 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-29 00:14+0200\n"
+"POT-Creation-Date: 2022-03-09 16:09+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,19 @@ msgstr ""
 msgid "Cockpit Starter Kit"
 msgstr "Cockpit Bausatz"
 
-#: src/app.jsx:42
+#: src/app.jsx:43
 msgid "Running on $0"
 msgstr "Läuft auf $0"
 
-#: src/manifest.json:0
+#: org.cockpit-project.starter-kit.metainfo.xml:6
+msgid "Scaffolding for a cockpit module"
+msgstr "Gerüst für ein Cockpit-Modul"
+
+#: org.cockpit-project.starter-kit.metainfo.xml:8
+msgid "Scaffolding for a cockpit module."
+msgstr "Gerüst für ein Cockpit-Modul."
+
+#: src/manifest.json:0 org.cockpit-project.starter-kit.metainfo.xml:5
 msgid "Starter Kit"
 msgstr "Bausatz"
 


### PR DESCRIPTION
This validates the i18n for the AppStream metadata introduced in commit
4377c4fe19.

---

Done by `make update-po` and translating the new sentences. The generated file (`make install DESTDIR=/tmp/x`) does use them, but it looks a little funny:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<component type="addon">
  <id>org.cockpit_project.starter_kit</id>
  <metadata_license>CC0-1.0</metadata_license>
  <name>Starter Kit</name>
  <name xml:lang="de">Bausatz</name>
  <summary>Scaffolding for a cockpit module</summary>
  <summary xml:lang="de">Gerüst für ein Cockpit-Modul</summary>
  <description>
    <p>
      Scaffolding for a cockpit module.
    </p>
    <p xml:lang="de">Gerüst für ein Cockpit-Modul.</p>
  </description>
  <extends>org.cockpit_project.cockpit</extends>
  <launchable type="cockpit-manifest">starter-kit</launchable>
</component>
```

I.e. `<name>` and `<summary>` look fine, but shouldn't it be `<description xml:lang="de">` with a single `<p>`? inside? This structure looks wrong.

@ptoscano FYI
