### PR TITLE
Makefile: allow setup of integration tests w/o running them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,9 +138,13 @@ $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) bots
 vm: $(VM_IMAGE)
 	echo $(VM_IMAGE)
 
+# convenience target to setup all the bits needed for the integration tests
+# without actually running them
+prepare-check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
+
 # run the browser integration tests; skip check for SELinux denials
 # this will run all tests/check-* and format them as TAP
-check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
+check: prepare-check
 	TEST_AUDIT_NO_SELINUX=1 test/common/run-tests
 
 # checkout Cockpit's bots for standard test VM images and API to launch them

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ the VM, possibly with extra options for tracing and halting on test failures
 
     TEST_OS=centos-8-stream test/check-application -tvs
 
+It is possible to setup the test environment without running the tests:
+
+    TEST_OS=centos-8-stream make prepare-check
+
 You can also run the test against a different Cockpit image, for example:
 
     TEST_OS=fedora-34 make check


### PR DESCRIPTION
Add a convenience target in Makefile to perform all the setup targets
for integration tests without actually running them.