### PR TITLE
Fix tests for Cockpit 265, some maintenance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,14 +155,14 @@ bots:
 # when you start a new project, use the latest release, and update it from time to time
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 262; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 265; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 262; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 265; \
 	    git checkout --force FETCH_HEAD -- pkg/lib; \
 	    git reset -- pkg/lib'
 	mv pkg/lib src/ && rmdir -p pkg

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ rpm: $(TARFILE) $(NODE_CACHE) $(SPEC)
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
 $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) bots
-	bots/image-customize --verbose --no-network --fresh \
+	bots/image-customize --no-network --fresh \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \
 		--script $(CURDIR)/test/vm.install $(TEST_OS)
 

--- a/test/check-application
+++ b/test/check-application
@@ -46,7 +46,6 @@ class TestApplication(testlib.MachineCase):
             b.wait_popup('display-language-modal')
         b.click("#display-language-modal [data-value='de-de'] button")
         b.click("#display-language-modal button.pf-m-primary")
-        b.expect_load()
         # HACK: work around language switching in Chrome not working in current session (Cockpit issue #8160)
         b.reload(ignore_cache=True)
         b.wait_visible("#content")

--- a/test/check-application
+++ b/test/check-application
@@ -46,8 +46,9 @@ class TestApplication(testlib.MachineCase):
             b.wait_popup('display-language-modal')
         b.click("#display-language-modal [data-value='de-de'] button")
         b.click("#display-language-modal button.pf-m-primary")
-        # HACK: work around language switching in Chrome not working in current session (Cockpit issue #8160)
-        b.reload(ignore_cache=True)
+        if self.system_before(265) and b.cdp.browser.name == "chromium":
+            # HACK: work around language switching in Chrome not working in current session (Cockpit issue #8160)
+            b.reload(ignore_cache=True)
         b.wait_visible("#content")
         # menu label (from manifest) should be translated
         b.wait_text("#host-apps a[href='/starter-kit']", "Bausatz")

--- a/test/check-application
+++ b/test/check-application
@@ -51,7 +51,9 @@ class TestApplication(testlib.MachineCase):
             b.reload(ignore_cache=True)
         b.wait_visible("#content")
         # menu label (from manifest) should be translated
-        b.wait_text("#host-apps a[href='/starter-kit']", "Bausatz")
+        # HACK: This regressed in cockpit 265, see https://github.com/cockpit-project/cockpit/pull/17145
+        if self.system_before(265) or not self.system_before(266):
+            b.wait_text("#host-apps a[href='/starter-kit']", "Bausatz")
 
         b.go("/starter-kit")
         b.enter_page("/starter-kit")


### PR DESCRIPTION
[1] regressed the translations of menu labels for external projects. This will get fixed in the next version [2]. Adjust the tests to not
break with Cockpit version == 265.

[1] https://github.com/cockpit-project/cockpit/commit/af5678b0be5547
[2] https://github.com/cockpit-project/cockpit/pull/17145

See [recent rawhide failure](https://artifacts.dev.testing-farm.io/c76133d1-6fb2-4835-8ccc-0a68afcfbf4c/work-alleA_O6p/log.txt). This will soon happen for F35/F36 as well, as the bodhi updates will move to stable soon.

I also added some other minor housekeeping updates.
