### PR TITLE
po: ignore js/jsx/html files under src/lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ po/$(PACKAGE_NAME).js.pot:
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
 		--keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
-		--from-code=UTF-8 $$(find src/ -name '*.js' -o -name '*.jsx')
+		--from-code=UTF-8 $$(find src/ \( -name '*.js' -o -name '*.jsx' \) \! -path 'src/lib/*')
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST)
-	po/html2po -o $@ $$(find src -name '*.html')
+	po/html2po -o $@ $$(find src -name '*.html' \! -path 'src/lib/*')
 
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST)
 	po/manifest2po src/manifest.json -o $@


### PR DESCRIPTION
Cockpit's PF/React/build library (`pkg/lib` from cockpit.git) is checked
out as src/lib, so exclude it from the search of js/jsx, and html
sources for the extraction of i18n messages.

This avoids the cockpit messages in case the message extraction is
performed in a source tree after build.