### PR TITLE
Makefile: add convenience 'devel-uninstall' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,11 @@ devel-install: $(WEBPACK_TEST)
 	mkdir -p ~/.local/share/cockpit
 	ln -s `pwd`/dist ~/.local/share/cockpit/$(PACKAGE_NAME)
 
+# assumes that there was symlink set up using the above devel-install target,
+# and removes it
+devel-uninstall:
+	rm -f ~/.local/share/cockpit/$(PACKAGE_NAME)
+
 print-version:
 	@echo "$(VERSION)"
 
@@ -191,4 +196,4 @@ $(NODE_MODULES_TEST): package.json
 	env -u NODE_ENV npm install
 	env -u NODE_ENV npm prune
 
-.PHONY: all clean install devel-install print-version dist node-cache rpm check vm update-po print-vm
+.PHONY: all clean install devel-install print-version dist node-cache rpm check vm update-po print-vm devel-uninstall

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ automatically minified and compressed. Set `NODE_ENV=production` if you want to
 duplicate this behavior.
 
 For development, you usually want to run your module straight out of the git
-tree. To do that, link that to the location were `cockpit-bridge` looks for packages:
+tree. To do that, run `make devel-install`, which links your checkout to the
+location were cockpit-bridge looks for packages. If you prefer to do
+this manually:
 
 ```
 mkdir -p ~/.local/share/cockpit
@@ -48,6 +50,11 @@ the code changes by setting the `RSYNC` environment variable to
 the remote hostname.
 
     $ RSYNC=c make watch
+
+To "uninstall" the locally installed version, run `make devel-uninstall`, or
+remove manually the symlink:
+
+    rm ~/.local/share/cockpit/starter-kit
 
 # Running eslint
 


### PR DESCRIPTION
Add a simple convenience target to "undo" what the devel-install did
(creating a symlink to `~/.local/share/cockpit`), i.e. simply removing
that symlink.

Suggested by: Christopher Snyder