### PR TITLE
metainfo: add few more URLs/references

### DIFF
--- a/org.cockpit-project.starter-kit.metainfo.xml
+++ b/org.cockpit-project.starter-kit.metainfo.xml
@@ -11,4 +11,7 @@
   </description>
   <extends>org.cockpit_project.cockpit</extends>
   <launchable type="cockpit-manifest">starter-kit</launchable>
+  <url type="homepage">https://github.com/cockpit-project/starter-kit</url>
+  <url type="bugtracker">https://github.com/cockpit-project/starter-kit/issues</url>
+  <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>


### PR DESCRIPTION
Even if this module is a template, add a couple more of keys to the
AppStream XML file; this way other projects can get few more hints.