### PR TITLE
Makefile: drop `$(NODE_MODULES_TEST)` dependency from `prepare-check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ print-vm:
 
 # convenience target to setup all the bits needed for the integration tests
 # without actually running them
-prepare-check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
+prepare-check: $(VM_IMAGE) test/common
 
 # run the browser integration tests; skip check for SELinux denials
 # this will run all tests/check-* and format them as TAP


### PR DESCRIPTION
The existing dependency system will already do the needed build steps
(including fetching the nodejs modules) to prepare the image for
testing, so there is no need for the tests-related target to do that.

Especially when using an own test image the assumption is that the
cockpit plugin is already installed, and thus there is no need to fetch
the nodejs modules.