### PR TITLE
webpack: Always regenerate and clean up dist/

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,8 @@ module.exports = {
     externals: { "cockpit": "cockpit" },
     devtool: "source-map",
     stats: "errors-warnings",
+    // always regenerate dist/, so make rules work
+    output: { clean: true, compareBeforeEmit: false },
 
     optimization: {
         minimize: production,


### PR DESCRIPTION
By default, webpack does not clean up dist/, so when you e.g. touch the
code and rebuild with `NODE_ENV=devel`, the old compressed assets from
a previous `production` build were left in place, and cockpit could
serve the old wrong ones. Enable the `clean` output option to fix this [1].

Also force the rewrite of all files with `compareBeforeEmit: false`, so
that the time stamps actually get updated on a webpack run. This fixes
`make` rules and unnecessary rebuilds when nothing changed.

Fixes #563

[1] https://webpack.js.org/configuration/output/#outputclean

----

See the linked issue for reproducer, but the simplest one is:
```
make
touch src/app.jsx
make  # should rebuild
make  # should do nothing
```