### PR TITLE
`Makefile`: avoid spurious echo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,11 +150,11 @@ $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) bots test/vm.install
 
 # convenience target for the above
 vm: $(VM_IMAGE)
-	echo $(VM_IMAGE)
+	@echo $(VM_IMAGE)
 
 # convenience target to print the filename of the test image
 print-vm:
-	echo $(VM_IMAGE)
+	@echo $(VM_IMAGE)
 
 # convenience target to setup all the bits needed for the integration tests
 # without actually running them


### PR DESCRIPTION
Disable the printing of the echo commands that write the filename of the
VM image for tests in the `vm` and `print-vm` targets.

This makes it possible to use their outputs, especially the `print-vm`
target.