### PR TITLE
Fedora packaging fixes

### DIFF
--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -7,6 +7,9 @@ License: LGPLv2+
 Source0: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/%{name}-%{version}.tar.xz
 Source1: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/%{name}-node-%{version}.tar.xz
 BuildArch: noarch
+%if 0%{?fedora}
+BuildRequires: nodejs-devel
+%endif
 BuildRequires:  nodejs
 BuildRequires: make
 BuildRequires: libappstream-glib

--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -27,10 +27,10 @@ Cockpit Starter Kit Example Module
 %prep
 %setup -q -n %{name}
 %setup -q -a 1 -n %{name}
-
-%build
 # ignore pre-built webpack in release tarball and rebuild it
 rm -rf dist
+
+%build
 ESLINT=0 NODE_ENV=production make
 
 %install

--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -40,6 +40,10 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 # drop source maps, they are large and just for debugging
 find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs --no-run-if-empty rm --verbose
 
+%check
+# this can't be meaningfully tested during package build; tests happen through
+# FMF (see plans/all.fmf) during package gating
+
 %files
 %doc README.md
 %license LICENSE dist/index.js.LICENSE.txt.gz

--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -7,6 +7,7 @@ License: LGPLv2+
 Source0: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/%{name}-%{version}.tar.xz
 Source1: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/%{name}-node-%{version}.tar.xz
 BuildArch: noarch
+ExclusiveArch: %{nodejs_arches} noarch
 %if 0%{?fedora}
 BuildRequires: nodejs-devel
 %endif


### PR DESCRIPTION
Forwardport to starter-kit of some packaging changes done during the Fedora review of cockpit-certificates:
https://github.com/cockpit-project/cockpit-certificates/pull/66

In particular:
- https://github.com/cockpit-project/cockpit-certificates/commit/097ea95f869db6deab6ef5aa5f1d94496c485cf5
- https://github.com/cockpit-project/cockpit-certificates/commit/320132f4778f311a66ea6d83dee290e06fdf3fef
- https://github.com/cockpit-project/cockpit-certificates/commit/d1b914f34424248bc5a447b98554015382a36cf2
- https://github.com/cockpit-project/cockpit-certificates/commit/dcd4efc696f823cb7d6bdc5d30bfab07fe325d79

Requires:
 - https://github.com/cockpit-project/bots/pull/3346
 - https://github.com/cockpit-project/bots/issues/3357
 - https://github.com/cockpit-project/bots/issues/3358