### PR TITLE
spec: automatic Provides generation from node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ POTFILES*
 tmp/
 /po/LINGUAS
 /tools
+/nodejs_provides.list

--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -21,6 +21,8 @@ BuildRequires: libappstream-glib-devel
 
 Requires: cockpit-bridge
 
+%{NODEJS_PROVIDES}
+
 %description
 Cockpit Starter Kit Example Module
 

--- a/packit.yaml
+++ b/packit.yaml
@@ -7,6 +7,7 @@ specfile_path: cockpit-starter-kit.spec
 copy_upstream_release_description: true
 
 srpm_build_deps:
+  - jq
   - make
   - npm
 


### PR DESCRIPTION
One of the requirements of Fedora packages that contain the result of
nodejs modules is to list them as Provides. Listing them manually in the
spec file would be a manual job, too error prone.

As solution, create the static list of nodejs modules as RPM Provides,
and include it in the spec file so it is used when building the RPM
package. This is done by querying `npm` for the list of locally installed
modules, and using `jq` to output that as Provides. There are manglings
done: 
- the `@` in the name of a module is removed, and `/` replaced with `-`
- e.g. `-alpha` or `-beta-` in the version of a module are turned into
  `~something`, as `-` is not accepted as version by RPM (whereas the
  tilde is the compliant way for pre-releases in versioning guidelines

Sadly this static inclusion is the only possible way at the moment,
as a in-package dependency generator is not possible, nor any other form
of dynamic filling of package relationships only at build/install time.