### PR TITLE
packaging: Drop unnecessary cockpit-system dependency

### DIFF
--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -19,7 +19,7 @@ BuildRequires: gettext
 BuildRequires: libappstream-glib-devel
 %endif
 
-Requires: cockpit-system
+Requires: cockpit-bridge
 
 %description
 Cockpit Starter Kit Example Module


### PR DESCRIPTION
All cockpit extensions should only require the bridge, at least as long
as they are independent from any other page (which is usually the case).
We still need cockpit-system for the tests (thus keep it in
test/browser/main.fmf), but it is perfectly reasonable to look at a
particular Cockpit page via the "remote hosts" panel, cockpit-desktop,
or Cockpit Client.