### PR TITLE
cirrus: Run tests with Firefox

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,4 +18,5 @@ test_task:
   # test PO template generation
   pot_build_script: make po/starter-kit.pot
 
-  check_script: TEST_JOBS=$(nproc) TEST_OS=$TEST_OS make check
+  # chromium has too little /dev/shm, and we can't make that bigger
+  check_script: TEST_BROWSER=firefox TEST_JOBS=$(nproc) TEST_OS=$TEST_OS make check


### PR DESCRIPTION
The GKE container only has the default 64 MiB /dev/shm, which is not
enough for Chromium. It cannot be remounted from inside the container,
and chromium's `--disable-dev-shm-usage` option does not actually work,
so run the tests with Firefox instead.

----

The test [often fails](https://github.com/cockpit-project/starter-kit/pull/584/checks?check_run_id=6854783505) due to chromium 
crashing with

    [0613/034633.820852:ERROR:broker_posix.cc(46)] Received unexpected number of handles

which is because it has a too small /dev/shm.

 - ~Requires https://github.com/cockpit-project/cockpit/pull/17446~ -- the CLI option does not work