### PR TITLE
packaging: Disable webpack rebuild in RHEL/CentOS 8

### DIFF
--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -11,7 +11,7 @@ ExclusiveArch: %{nodejs_arches} noarch
 %if 0%{?fedora}
 BuildRequires: nodejs-devel
 %endif
-BuildRequires:  nodejs
+BuildRequires: nodejs
 BuildRequires: make
 BuildRequires: libappstream-glib
 BuildRequires: gettext
@@ -27,7 +27,10 @@ Cockpit Starter Kit Example Module
 %prep
 %autosetup -n %{name} -a 1
 # ignore pre-built webpack in release tarball and rebuild it
+# but keep it in RHEL/CentOS-8, as that has a too old nodejs
+%if ! 0%{?rhel} || 0%{?rhel} >= 9
 rm -rf dist
+%endif
 
 %build
 ESLINT=0 NODE_ENV=production make


### PR DESCRIPTION
RHEL 8 has node 10, which is too old for current
jest-worker/eslint/stylelint NPM modules.

The webpack rebuild during RPM build was introduced to satisfy Fedora
packaging policy, but it's not a requirement on RHEL 8. So just disable
it there.

--- 

See PR #587 for the failure logs and explanation.