### PR TITLE
Install into /usr/local/ by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export TEST_OS
 TARFILE=$(RPM_NAME)-$(VERSION).tar.xz
 NODE_CACHE=$(RPM_NAME)-node-$(VERSION).tar.xz
 SPEC=$(RPM_NAME).spec
+PREFIX ?= /usr/local
 APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
@@ -91,12 +92,12 @@ clean:
 	rm -f po/LINGUAS
 
 install: $(WEBPACK_TEST) po/LINGUAS
-	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
-	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
-	mkdir -p $(DESTDIR)/usr/share/metainfo/
+	mkdir -p $(DESTDIR)$(PREFIX)/share/cockpit/$(PACKAGE_NAME)
+	cp -r dist/* $(DESTDIR)$(PREFIX)/share/cockpit/$(PACKAGE_NAME)
+	mkdir -p $(DESTDIR)$(PREFIX)/share/metainfo/
 	msgfmt --xml -d po \
 		--template $(APPSTREAMFILE) \
-		-o $(DESTDIR)/usr/share/metainfo/$(APPSTREAMFILE)
+		-o $(DESTDIR)$(PREFIX)/share/metainfo/$(APPSTREAMFILE)
 
 # this requires a built source tree and avoids having to install anything system-wide
 devel-install: $(WEBPACK_TEST)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ make
 
 # Installing
 
-`make install` compiles and installs the package in `/usr/share/cockpit/`. The
+`make install` compiles and installs the package in `/usr/local/share/cockpit/`. The
 convenience targets `srpm` and `rpm` build the source and binary rpms,
 respectively. Both of these make use of the `dist` target, which is used
 to generate the distribution tarball. In `production` mode, source files are

--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -36,7 +36,7 @@ rm -rf dist
 ESLINT=0 NODE_ENV=production make
 
 %install
-%make_install
+%make_install PREFIX=/usr
 
 # drop source maps, they are large and just for debugging
 find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs --no-run-if-empty rm --verbose


### PR DESCRIPTION
/usr is package manager territory, and not even writable on OSTree based systems such as Fedora CoreOS or RHEL Edge. This has been common and good practice in autotools for decades.

You can still override this with `make install PREFIX=...`. Use that in the RPM spec file.

---

Adapted from https://github.com/cockpit-project/cockpit-ostree/pull/281