### PR TITLE
cirrus: Move to Fedora 37

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ container:
 test_task:
   env:
     matrix:
-      - TEST_OS: fedora-35
+      - TEST_OS: fedora-37
       - TEST_OS: centos-8-stream
 
   fix_kvm_script: sudo chmod 666 /dev/kvm


### PR DESCRIPTION
There is no Fedora 35 image any more.

---

See [failed test](https://github.com/cockpit-project/starter-kit/pull/606/checks?check_run_id=9194202641) in #606