### PR TITLE
.github: update release action workflow

### DIFF
--- a/.github/workflows/release.yml.disabled
+++ b/.github/workflows/release.yml.disabled
@@ -29,6 +29,6 @@ jobs:
         run: make dist
 
       - name: Publish GitHub release
-        uses: cockpit-project/action-release@62db9d9850a1adec300500d84035c4f523fd5290
+        uses: cockpit-project/action-release@88d994da62d1451c7073e26748c18413fcdf46e9
         with:
           filename: "TARNAME-${{ github.ref_name }}.tar.xz"


### PR DESCRIPTION
Our latest action-release workflow no longer uses a deprecated github-script version.