### PR TITLE
Use whole path in patternfly imports

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -19,7 +19,8 @@
 
 import cockpit from 'cockpit';
 import React from 'react';
-import { Alert, Card, CardTitle, CardBody } from '@patternfly/react-core';
+import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
+import { Card, CardBody, CardTitle } from "@patternfly/react-core/dist/esm/components/Card/index.js";
 
 const _ = cockpit.gettext;
 


### PR DESCRIPTION
Otherwise we rely on treeshaking mechanisms to remove unused code, thus making our bundle size more vulnerable to bundler's ability to drop dead code.