### PR TITLE
README: document development dependencies for Fedora/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 Scaffolding for a [Cockpit](https://cockpit-project.org/) module.
 
+# Development dependencies
+
+On Debian/Ubuntu:
+
+    $ sudo apt install gettext nodejs npm make
+
+On Fedora:
+
+    $ sudo dnf install gettext nodejs npm make
+
+
 # Getting and building the source
 
-Make sure you have `npm` available (usually from your distribution package).
 These commands check out the source and build it into the `dist/` directory:
 
 ```


### PR DESCRIPTION
Document what is required to get a test VM build done, for some new contributors the gettext dependency is not obvious to resolve.

See for example https://github.com/cockpit-project/cockpit-podman/pull/1218