### PR TITLE
Run `npm install` with `--ignore-scripts`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ $(NODE_MODULES_TEST): package.json
 	# if it exists already, npm install won't update it; force that so that we always get up-to-date packages
 	rm -f package-lock.json
 	# unset NODE_ENV, skips devDependencies otherwise
-	env -u NODE_ENV npm install
+	env -u NODE_ENV npm install --ignore-scripts
 	env -u NODE_ENV npm prune
 
 .PHONY: all clean install devel-install devel-uninstall print-version dist node-cache rpm prepare-check check vm print-vm


### PR DESCRIPTION
https://github.com/cockpit-project/bots/blob/main/npm does that as well. We don't expect/depend on scripts, and this closes at least one major attack vector of `npm install` against developer machines.