### PR TITLE
packit: Enable tests on aarch64

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -25,8 +25,10 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
+      - fedora-latest-aarch64
       - centos-stream-8
       - centos-stream-9
+      - centos-stream-9-aarch64
 
   # Build releases in COPR: https://packit.dev/docs/configuration/#copr_build
   #- job: copr_build


### PR DESCRIPTION
I'm looking forward to the first result -- anything could be possible, from "just works" to "beyond repair" :crossed_fingers: 

 - Builds on top of PR #632 to fix nodejs installation on Fedora