### PR TITLE
packaging: Declare bundled NPM dependencies in spec file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,9 @@ po/LINGUAS:
 # Build/Install/dist
 #
 
-%.spec: packaging/%.spec.in
-	sed -e 's/%{VERSION}/$(VERSION)/g' $< > $@
+$(SPEC): packaging/$(SPEC).in $(NODE_MODULES_TEST)
+	provides=$$(npm ls --omit dev --package-lock-only --depth=Infinity | grep -Eo '[^[:space:]]+@[^[:space:]]+' | sort -u | sed 's/^/Provides: bundled(npm(/; s/\(.*\)@/\1)) = /'); \
+	awk -v p="$$provides" '{gsub(/%{VERSION}/, "$(VERSION)"); gsub(/%{NPM_PROVIDES}/, p)}1' $< > $@
 
 $(DIST_TEST): $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP) $(shell find src/ -type f) package.json webpack.config.js
 	NODE_ENV=$(NODE_ENV) node_modules/.bin/webpack

--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -18,6 +18,8 @@ BuildRequires: libappstream-glib-devel
 
 Requires: cockpit-bridge
 
+%{NPM_PROVIDES}
+
 %description
 Cockpit Starter Kit Example Module
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2180520

Turn the pattern make rule into an explicit one, as pattern rules don't
support dependencies. We only need it for our single spec file anyway.

----

```
❱❱❱ rpm -q --provides -p cockpit-starter-kit-1-1.fc37.noarch.rpm
bundled(npm(@patternfly/patternfly)) = 4.224.4
bundled(npm(@patternfly/react-core)) = 4.276.8
bundled(npm(@patternfly/react-icons)) = 4.93.6
bundled(npm(@patternfly/react-styles)) = 4.92.6
bundled(npm(@patternfly/react-tokens)) = 4.94.6
bundled(npm(attr-accept)) = 1.1.3
bundled(npm(core-js)) = 2.6.12
bundled(npm(file-selector)) = 0.1.19
bundled(npm(focus-trap)) = 6.9.2
bundled(npm(js-tokens)) = 4.0.0
bundled(npm(loose-envify)) = 1.4.0
bundled(npm(object-assign)) = 4.1.1
bundled(npm(popper.js)) = 1.16.1
bundled(npm(prop-types)) = 15.8.1
bundled(npm(prop-types-extra)) = 1.1.1
bundled(npm(react)) = 17.0.2
bundled(npm(react-dom)) = 17.0.2
bundled(npm(react-dropzone)) = 9.0.0
bundled(npm(react-is)) = 16.13.1
bundled(npm(scheduler)) = 0.20.2
bundled(npm(tabbable)) = 5.3.3
bundled(npm(tippy.js)) = 5.1.2
bundled(npm(tslib)) = 2.5.0
bundled(npm(warning)) = 4.0.3
[... some other unrelated noise ..]
```