### PR TITLE
.github: update checkout action to v3

### DIFF
--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -19,7 +19,7 @@ jobs:
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run npm-update bot
         run: |

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -19,7 +19,7 @@ jobs:
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run npm-update bot
         run: |


### PR DESCRIPTION
Seems we forgot starter-kit, most projects already use the v3 action.