### PR TITLE
.github: add Cockpit library update action

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -1,0 +1,27 @@
+name: cockpit-lib-update
+on:
+  schedule:
+    - cron: '0 2 * * 4'
+  # can be run manually on https://github.com/cockpit-project/starter-kit/actions
+  workflow_dispatch:
+jobs:
+  cockpit-lib-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y make
+
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Run cockpit-lib-update
+        run: |
+          make bots
+          bots/cockpit-lib-update


### PR DESCRIPTION
This action works similar to the npm-update workflow, it creates a PR every Thursday (usually after the Cockpit release) to update the COCKPIT_REPO_COMMIT to the latest version.

---

Test run:

 https://github.com/jelly/starter-kit/actions/runs/4722440632
https://github.com/jelly/starter-kit/pull/3