### PR TITLE
packit: Move to nodejs-npm SRPM dependency

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -8,7 +8,7 @@ copy_upstream_release_description: true
 
 srpm_build_deps:
   - make
-  - npm
+  - nodejs-npm
 
 actions:
   post-upstream-clone:


### PR DESCRIPTION
`npm` recently became broken in Fedora and doesn't provide the `npm` binary any more. As a workaround, move to `nodejs-npm` to fix the srpm build.

---

Fixes [this mess](https://download.copr.fedorainfracloud.org/results/packit/cockpit-project-starter-kit-639/srpm-builds/05798718/builder-live.log.gz). Once this lands, this needs to b applied to cockpit-{ostree,certificates}, too.