### PR TITLE
Makefile: Update Cockpit lib to a2a1f34d567de5fc512801018e15e6b6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = 6073b2703acd68e216bd9dbc116c30d2d7a9701c # 288.1 + esbuild plugin updates
+COCKPIT_REPO_COMMIT = a2a1f34d567de5fc512801018e15e6b6810cf261 # 290
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'


### PR DESCRIPTION
This was a local test run for validating https://github.com/cockpit-project/bots/pull/4677 . It can land, but I actually want to send some starter-kit PR to change the workflows, and also fix another bug. So let's not for now.