### PR TITLE
workflows: Update to ubuntu-latest, set explicit permissions

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   cockpit-lib-update:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   npm-update:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
         run: |

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   npm-update:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - name: Set up dependencies
         run: |


### PR DESCRIPTION
I restricted our default workflow permissions now:

![image](https://user-images.githubusercontent.com/200109/233274854-186390d1-e686-4ca8-a88e-a4ddd088df4b.png)

This has no influence on workflows with an explicit `permissions:` (and now they all have). Let's test all of them to make sure they still work.

 - [x] [npm-update](https://github.com/cockpit-project/starter-kit/actions/runs/4751164558)
 - [x] [npm-update-pf](https://github.com/cockpit-project/starter-kit/actions/runs/4751163656/jobs/8440024937)
 - [x] cockpit-lib-update (~blocked on https://github.com/cockpit-project/bots/pull/4677~) [successful workflow](https://github.com/cockpit-project/starter-kit/actions/runs/4752178616) produced #644