### PR TITLE
package.json: Pin down versions of @patternfly/react-{styles,icons}

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   "dependencies": {
     "@patternfly/patternfly": "5.0.0-alpha.40",
     "@patternfly/react-core": "5.0.0-alpha.72",
+    "@patternfly/react-styles": "5.0.0-alpha.7",
+    "@patternfly/react-icons": "5.0.0-alpha.10",
     "react": "17.0.2",
     "react-dom": "17.0.2"
   }


### PR DESCRIPTION
These are already installed as dependencies, and we do the same in other Cockpit projects. The latest react-styles version became incompatible with the react-core version, causing a build failure.

----

See https://github.com/cockpit-project/bots/pull/4746 and other failed image refreshes.