### PR TITLE
Workaround Github actions dubious permissions error

### DIFF
--- a/.github/workflows/release.yml.disabled
+++ b/.github/workflows/release.yml.disabled
@@ -22,6 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+      - name: Pacify git's permission check
+        run: git config --global --add safe.directory /__w/
+
       - name: Workaround for https://github.com/actions/checkout/pull/697
         run: git fetch --force origin $(git describe --tags):refs/tags/$(git describe --tags)
 


### PR DESCRIPTION
"fatal: detected dubious ownership in repository at..."

Code used from cockpit-machines.