### PR TITLE
build.js: support flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ $(DIST_TEST): $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP) $(shell find src/ -type
 	NODE_ENV=$(NODE_ENV) ./build.js
 
 watch: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	NODE_ENV=$(NODE_ENV) npm run watch
+	NODE_ENV=$(NODE_ENV) ./build.js --watch
 
 clean:
 	rm -rf dist/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can also use
 [watch mode](https://esbuild.github.io/api/#watch) to
 automatically update the bundle on every code change with
 
-    $ npm run watch
+    $ ./build.js -w
 
 or
 
@@ -110,7 +110,7 @@ During fast iterative development, you can also choose to not run eslint/styleli
 This speeds up the build and avoids build failures due to e. g. ill-formatted
 css or other issues:
 
-    $ make LINT=0
+    $ ./build.js -es
 
 # Running tests locally
 

--- a/build.js
+++ b/build.js
@@ -14,13 +14,21 @@ import { esbuildStylesPlugins } from './pkg/lib/esbuild-common.js';
 import { eslintPlugin } from './pkg/lib/esbuild-eslint-plugin.js';
 import { stylelintPlugin } from './pkg/lib/esbuild-stylelint-plugin.js';
 
+const production = process.env.NODE_ENV === 'production';
 const useWasm = os.arch() !== 'x64';
 const esbuild = (await import(useWasm ? 'esbuild-wasm' : 'esbuild')).default;
+const lintDefault = process.env.LINT ? process.env.LINT === '0' : production;
 
-const production = process.env.NODE_ENV === 'production';
-const watchMode = process.env.ESBUILD_WATCH === "true";
-// linters dominate the build time, so disable them for production builds by default, but enable in watch mode
-const lint = process.env.LINT ? (process.env.LINT !== '0') : (watchMode || !production);
+const parser = (await import('argparse')).default.ArgumentParser();
+parser.add_argument('-r', '--rsync', { help: "rsync bundles to ssh target after build", metavar: "HOST" });
+parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable watch mode", default: process.env.ESBUILD_WATCH === "true" });
+parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting", default: lintDefault });
+parser.add_argument('-s', '--no-stylelint', { action: 'store_true', help: "Disable stylelint linting", default: lintDefault });
+const args = parser.parse_args();
+
+if (args.rsync)
+    process.env.RSYNC = args.rsync;
+
 // List of directories to use when using import statements
 const nodePaths = ['pkg/lib'];
 const outdir = 'dist';
@@ -87,12 +95,8 @@ const context = await esbuild.context({
     target: ['es2020'],
     plugins: [
         cleanPlugin(),
-        ...lint
-            ? [
-                stylelintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(css?|scss?)$') }),
-                eslintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(jsx?|js?)$') })
-            ]
-            : [],
+        ...args.no_stylelint ? [] : [stylelintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(css?|scss?)$') })],
+        ...args.no_eslint ? [] : [eslintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(jsx?|js?)$') })],
         // Esbuild will only copy assets that are explicitly imported and used
         // in the code. This is a problem for index.html and manifest.json which are not imported
         copy({
@@ -112,12 +116,12 @@ const context = await esbuild.context({
 try {
     await context.rebuild();
 } catch (e) {
-    if (!watchMode)
+    if (!args.watch)
         process.exit(1);
     // ignore errors in watch mode
 }
 
-if (watchMode) {
+if (args.watch) {
     const on_change = async path => {
         console.log("change detected:", path);
         await context.cancel();

--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -32,7 +32,7 @@ rm -rf dist
 %endif
 
 %build
-ESLINT=0 NODE_ENV=production make
+LINT=0 NODE_ENV=production make
 
 %install
 %make_install PREFIX=/usr


### PR DESCRIPTION
Adds flags to build.js to use rsync, disable linting and use watch mode.