### PR TITLE
fmf: Plumb through $TEST_* variables for unexpected messages

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ container:
 test_task:
   env:
     matrix:
-      - TEST_OS: fedora-37
+      - TEST_OS: fedora-39
       - TEST_OS: centos-8-stream
 
   fix_kvm_script: sudo chmod 666 /dev/kvm

--- a/Makefile
+++ b/Makefile
@@ -172,10 +172,10 @@ print-vm:
 # without actually running them
 prepare-check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
 
-# run the browser integration tests; skip check for SELinux denials
+# run the browser integration tests
 # this will run all tests/check-* and format them as TAP
 check: prepare-check
-	TEST_AUDIT_NO_SELINUX=1 test/common/run-tests ${RUN_TESTS_OPTIONS}
+	test/common/run-tests ${RUN_TESTS_OPTIONS}
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 bots: $(COCKPIT_REPO_STAMP)

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -4,3 +4,7 @@ discover:
     how: fmf
 execute:
     how: tmt
+
+# Let's handle them upstream only, don't break Fedora/RHEL reverse dependency gating
+environment:
+    TEST_AUDIT_NO_SELINUX: 1

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -22,13 +22,16 @@ mv .git dot-git
 
 . /etc/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
-export TEST_AUDIT_NO_SELINUX=1
 
 if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 
 EXCLUDES=""
+
+# make it easy to check in logs
+echo "TEST_ALLOW_JOURNAL_MESSAGES: ${TEST_ALLOW_JOURNAL_MESSAGES:-}"
+echo "TEST_AUDIT_NO_SELINUX: ${TEST_AUDIT_NO_SELINUX:-}"
 
 RC=0
 test/common/run-tests --nondestructive --machine 127.0.0.1:22 --browser 127.0.0.1:9090 $EXCLUDES || RC=$?


### PR DESCRIPTION
This will allow us to control the value from test plans, in particular for disabling at least some unexpected message checks for reverse dependency testing. We don't want to disable unexpected messages in general for fmf, as we are looking for exactly these in e.g. selinux-policy reverse dependency tests.

Move from `su` to `runtest`, as with the former it's impossible to plumb through variables with non-trivial characters, as they cannot be quoted.

Taken from https://github.com/cockpit-project/cockpit-podman/commit/c38692fa4ce66