### PR TITLE
package.json: document the required nodejs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "repository": "git@github.com:cockpit/starter-kit.git",
   "author": "",
   "license": "LGPL-2.1",
+  "engines": {
+    "node": ">= 16"
+  },
   "scripts": {
     "watch": "ESBUILD_WATCH='true' ./build.js",
     "build": "./build.js",


### PR DESCRIPTION
To avoid issues about not being able to run make / npm install. This sadly only produces a warning, but that hint might be good enough.

$ npm install
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: undefined,
npm WARN EBADENGINE   required: { node: '>= 18' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '9.8.1' }
npm WARN EBADENGINE }

I can only install nodejs 16 as lowest nodejs version easily, do the example warning uses `node: ">= 18"`