### PR TITLE
Add ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[tool.ruff]
+select = [
+    "A",       # flake8-builtins
+    "B",       # flake8-bugbear
+    "C4",      # flake8-comprehensions
+    "D300",    # pydocstyle: Forbid ''' in docstrings
+    "E",       # pycodestyle
+    "EXE",     # flake8-executable
+    "F",       # pyflakes
+    "FBT",     # flake8-boolean-trap
+    "G",       # flake8-logging-format
+    "I",       # isort
+    "ICN",     # flake8-import-conventions
+    "ISC",     # flake8-implicit-str-concat
+    "PLE",     # pylint errors
+    "PGH",     # pygrep-hooks
+    "RSE",     # flake8-raise
+    "RUF",     # ruff rules
+    "T10",     # flake8-debugger
+    "TCH",     # flake8-type-checking
+    "UP032",   # f-string
+    "W",       # warnings (mostly whitespace)
+    "YTT",     # flake8-2020
+]
+exclude = [
+    ".git/",
+    "modules/",
+    "node_modules/",
+]
+ignore = [
+    "FBT002", # Boolean default value in function definition
+    "FBT003", # Boolean positional value in function call
+]
+line-length = 118
+src = []
+
+[tool.ruff.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+
+[tool.ruff.isort]
+known-first-party = ["cockpit"]

--- a/test/check-application
+++ b/test/check-application
@@ -6,8 +6,10 @@
 
 import testlib
 
-# Nondestructive tests all run in the same running VM. This allows them to run in Packit, Fedora, and RHEL dist-git gating
-# They must not permanently change any file or configuration on the system in a way that influences other tests.
+
+# Nondestructive tests all run in the same running VM. This allows them to run in Packit, Fedora, and
+# RHEL dist-git gating. They must not permanently change any file or configuration on the system in a
+# way that influences other tests.
 @testlib.nondestructive
 class TestApplication(testlib.MachineCase):
     def testBasic(self):

--- a/test/run
+++ b/test/run
@@ -12,3 +12,5 @@ export RUN_TESTS_OPTIONS=--track-naughties
 export LINT=1
 
 make check
+
+ruff check test/check*


### PR DESCRIPTION
Apply our standard set of rules from our cockpit projects, and fix some minor fallout:
```
test/check-application:7:1: I001 [*] Import block is un-sorted or un-formatted
test/check-application:9:119: E501 Line too long (122 > 118 characters)
```

Run ruff in CI to ensure we don't break it.