### PR TITLE
stylelint: handle stylelint-scss deprecation

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -26,6 +26,8 @@
 	"no-duplicate-selectors": null,
 	"scss/at-extend-no-missing-placeholder": null,
 	"scss/at-import-partial-extension": null,
+	"scss/at-import-no-partial-leading-underscore": null,
+	"scss/load-no-partial-leading-underscore": true,
 	"scss/at-mixin-pattern": null,
 	"scss/comment-no-empty": null,
 	"scss/dollar-variable-pattern": null,


### PR DESCRIPTION
stylelint-sccs deprecated at-import-partial-leading-underscore in a minor version update while stylelint-config-recommended-scss still enables it causing an error when running stylelint.