### PR TITLE
.gitignore: merge back changes from Cockpit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,33 @@
-*~
-*.retry
-*.tar.xz
+# Please keep this file sorted (LC_COLLATE=C.UTF-8),
+# grouped into the 3 categories below:
+#  - general patterns (match in all directories)
+#  - patterns to match files at the toplevel
+#  - patterns to match files in subdirs
+
+# general patterns
+*.pyc
 *.rpm
-node_modules/
-dist/
-/*.spec
-/.vagrant
-package-lock.json
-Test*FAIL*
+
+# toplevel (/...)
+/Test*.html
+/Test*.json
+/Test*.log
+/Test*.png
 /bots
-test/common/
-test/images/
-pkg
-*.pot
-POTFILES*
-tmp/
-/po/LINGUAS
-/tools
+/cockpit-*.tar.xz
+/cockpit-navigator.spec
+/dist/
+/package-lock.json
+/pkg/
+/node_modules/
+/tmp/
+/tools/
+ 
+# subdirs (/subdir/...)
+/packaging/arch/PKGBUILD
+/packaging/debian/changelog
+/po/*.pot
+ /po/LINGUAS
+/test/common/
+/test/images/
+/test/static-code


### PR DESCRIPTION
In machines/podman and Cockpit we sorted and re-organised the gitignore file. In navigator I noticed that starter-kit did not have these changes yet and so we had to re-apply them so let's fix it in the source.