### PR TITLE
Use Cockpit's shared static code checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 118

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all: $(DIST_TEST)
 COCKPIT_REPO_FILES = \
 	pkg/lib \
 	test/common \
+	test/static-code \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
@@ -177,6 +178,9 @@ prepare-check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common
 # this will run all tests/check-* and format them as TAP
 check: prepare-check
 	test/common/run-tests ${RUN_TESTS_OPTIONS}
+
+codecheck: test/static-code $(NODE_MODULES_TEST)
+	test/static-code
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 bots: $(COCKPIT_REPO_STAMP)

--- a/build.js
+++ b/build.js
@@ -95,8 +95,8 @@ const context = await esbuild.context({
     target: ['es2020'],
     plugins: [
         cleanPlugin(),
-        ...args.no_stylelint ? [] : [stylelintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(css?|scss?)$') })],
-        ...args.no_eslint ? [] : [eslintPlugin({ filter: new RegExp(cwd + '\/src\/.*\.(jsx?|js?)$') })],
+        ...args.no_stylelint ? [] : [stylelintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(css?|scss?)$') })],
+        ...args.no_eslint ? [] : [eslintPlugin({ filter: new RegExp(cwd + '/src/.*\\.(jsx?|js?)$') })],
         // Esbuild will only copy assets that are explicitly imported and used
         // in the code. This is a problem for index.html and manifest.json which are not imported
         copy({

--- a/test/run
+++ b/test/run
@@ -11,6 +11,5 @@ export RUN_TESTS_OPTIONS=--track-naughties
 # linters are off by default for production builds, but we want to run them in CI
 export LINT=1
 
+make codecheck
 make check
-
-ruff check test/check*


### PR DESCRIPTION
These will soon take over ESLint and stylelint, plus they also cover ruff and other goodies for the Python part. This supersedes the explicit ruff call.
    
This is already being used by cockpit-{podman,machines,navigator} etc.

---

Plus two preparatory commits.