### PR TITLE
Move eslint/stylelint to static-code tests, fix fmf attachments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ COCKPIT_REPO_FILES = \
 	$(NULL)
 
 COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
-COCKPIT_REPO_COMMIT = bc12d5e116b56ebc5509fde7191a2ac5c09b1018 # 310.1 + 17 commits
+COCKPIT_REPO_COMMIT = 1a28b31828e309aa2aba6076b1bcc5ee841ac8ea # 310.1 + 30 commits
 
 $(COCKPIT_REPO_FILES): $(COCKPIT_REPO_STAMP)
 COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ remove manually the symlink:
 Cockpit Starter Kit uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.js` and `.jsx` files.
 
-eslint is executed within every build.
+eslint is executed as part of `test/static-code`, aka. `make codecheck`.
 
 For developer convenience, the ESLint can be started explicitly by:
 
@@ -94,7 +94,7 @@ Rules configuration can be found in the `.eslintrc.json` file.
 Cockpit uses [Stylelint](https://stylelint.io/) to automatically check CSS code
 style in `.css` and `scss` files.
 
-styleint is executed within every build.
+styleint is executed as part of `test/static-code`, aka. `make codecheck`.
 
 For developer convenience, the Stylelint can be started explicitly by:
 
@@ -105,12 +105,6 @@ Violations of some rules can be fixed automatically by:
     $ npm run stylelint:fix
 
 Rules configuration can be found in the `.stylelintrc.json` file.
-
-During fast iterative development, you can also choose to not run eslint/stylelint.
-This speeds up the build and avoids build failures due to e. g. ill-formatted
-css or other issues:
-
-    $ ./build.js -es
 
 # Running tests locally
 

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -5,7 +5,7 @@ export TEST_BROWSER=${TEST_BROWSER:-firefox}
 
 TESTS="$(realpath $(dirname "$0"))"
 export SOURCE="$(realpath $TESTS/../..)"
-export LOGS="$(pwd)/logs"
+export LOGS="${TMT_TEST_DATA:-$(pwd)/logs}"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 


### PR DESCRIPTION
stylelint 16 causes a deadlock/crash in esbuild [1]. There's no movement on that issue, and we want stylelint 16 to be able to support the Browser Baseline 2023.

Follow https://github.com/cockpit-project/cockpit/commit/1a28b31828e and move the linters into test/static-code. This also starts to lint files which are outside of esbuild's realm, such as documentation and examples.

[1] https://github.com/evanw/esbuild/issues/3542

---

Second commit fixes the [empty test attachments](https://artifacts.dev.testing-farm.io/56e6f2b5-ef14-4fcd-b423-b2fb2e02dcb6/work-allwwyt_9rp/plans/all/execute/data/guest/default-0/test/browser-1/data/). They should look like in [podman](https://artifacts.dev.testing-farm.io/f982a089-d0db-4b45-ae35-77afff95bebd/work-misci4ldvlc3/plans/all/misc/execute/data/guest/default-0/test/browser/other-1/data/)