### PR TITLE
workflows: Switch release to cockpit/tasks container

### DIFF
--- a/.github/workflows/release.yml.disabled
+++ b/.github/workflows/release.yml.disabled
@@ -11,14 +11,14 @@ jobs:
   source:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cockpit-project/unit-tests
+      image: quay.io/cockpit/tasks:latest
       options: --user root
     permissions:
       # create GitHub release
       contents: write
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
The unit-tests container was dropped in
https://github.com/cockpit-project/cockpit/commit/f16f1fc14b88c

Also switch the template to current actions/checkout version.

---

After this lands, I'll apply it to all our other projects. Then we can drop https://ghcr.io/cockpit-project/unit-tests (which is deadware by now).