### PR TITLE
spec: Support SUSE specic BuildRequires

### DIFF
--- a/packaging/cockpit-starter-kit.spec.in
+++ b/packaging/cockpit-starter-kit.spec.in
@@ -7,10 +7,17 @@ License: LGPL-2.1-or-later
 Source0: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/%{name}-%{version}.tar.xz
 Source1: https://github.com/cockpit-project/starter-kit/releases/download/%{version}/%{name}-node-%{version}.tar.xz
 BuildArch: noarch
+%if ! 0%{?suse_version}
 ExclusiveArch: %{nodejs_arches} noarch
+%endif
 BuildRequires: nodejs
 BuildRequires: make
+%if 0%{?suse_version}
+# Suse's package has a different name
+BuildRequires: appstream-glib
+%else
 BuildRequires: libappstream-glib
+%endif
 BuildRequires: gettext
 %if 0%{?rhel} && 0%{?rhel} <= 8
 BuildRequires: libappstream-glib-devel


### PR DESCRIPTION
In order to [openSUSE tumbleweed testing image](https://github.com/cockpit-project/bots/pull/5954) pass tests in the starter kit, the spec file needs to be updated to support it.