### PR TITLE
test: More precise dropdown selector

### DIFF
--- a/test/check-application
+++ b/test/check-application
@@ -33,7 +33,7 @@ class TestApplication(testlib.MachineCase):
         b.switch_to_top()
         # the menu and dialog changed several times
         b.click("#toggle-menu")
-        b.click(".display-language-menu")
+        b.click("button.display-language-menu")
         b.wait_popup('display-language-modal')
         b.click("#display-language-modal [data-value='de-de'] button")
         b.click("#display-language-modal button.pf-m-primary")


### PR DESCRIPTION
Cockpit 315 changed the session menu from the deprecated PF Dropdown to
the new one, via cockpit-components-dropdown. `DropdownItem` now renders
the class name into *both* the `<li>` and the `<button>` inside of it,
so select the button to avoid an ambiguous selector.

----

https://artifacts.dev.testing-farm.io/b991462d-eb0f-49f6-a7b6-c950757e4199/