### PR TITLE
fmf: Restrict "-stream" TEST_OS suffix to CentOS 8/9

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -23,7 +23,7 @@ mv .git dot-git
 . /run/host/usr/lib/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 
-if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
+if [ "$TEST_OS" = "centos-8" ] || [ "$TEST_OS" = "centos-9" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 


### PR DESCRIPTION
Our c10s CI image is called "centos-10" without the -stream suffix. This fits better with `os-release` and makes the names shorter. Adjust the building of `$TEST_OS` accordingly.

[1] https://github.com/cockpit-project/bots/pull/6218

---

This also serves as a test run against our centos-10 image. It should already work without further changes.