### PR TITLE
dependabot: Group React and types packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,12 +15,19 @@ updates:
       esbuild:
         patterns:
           - "esbuild*"
-      stylelint:
-        patterns:
-          - "stylelint*"
       patternfly:
         patterns:
           - "@patternfly*"
+      react:
+        patterns:
+          - "react*"
+      stylelint:
+        patterns:
+          - "stylelint*"
+      types:
+        patterns:
+          - "@types*"
+          - "types*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Also sort the list alphabetically.

---

See #851 and #852, these shouldn't be updated individually.