### PR TITLE
test: Drop testing on CentOS 8 Stream

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ test_task:
   env:
     matrix:
       - TEST_OS: fedora-39
-      - TEST_OS: centos-8-stream
+      - TEST_OS: centos-9-stream
 
   fix_kvm_script: sudo chmod 666 /dev/kvm
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' packa
 RPM_NAME := cockpit-$(PACKAGE_NAME)
 VERSION := $(shell T=$$(git describe 2>/dev/null) || T=1; echo $$T | tr '-' '.')
 ifeq ($(TEST_OS),)
-TEST_OS = centos-8-stream
+TEST_OS = centos-9-stream
 endif
 export TEST_OS
 TARFILE=$(RPM_NAME)-$(VERSION).tar.xz

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Rules configuration can be found in the `.stylelintrc.json` file.
 # Running tests locally
 
 Run `make check` to build an RPM, install it into a standard Cockpit test VM
-(centos-8-stream by default), and run the test/check-application integration test on
+(centos-9-stream by default), and run the test/check-application integration test on
 it. This uses Cockpit's Chrome DevTools Protocol based browser tests, through a
 Python API abstraction. Note that this API is not guaranteed to be stable, so
 if you run into failures and don't want to adjust tests, consider checking out
@@ -120,15 +120,15 @@ After the test VM is prepared, you can manually run the test without rebuilding
 the VM, possibly with extra options for tracing and halting on test failures
 (for interactive debugging):
 
-    TEST_OS=centos-8-stream test/check-application -tvs
+    TEST_OS=centos-9-stream test/check-application -tvs
 
 It is possible to setup the test environment without running the tests:
 
-    TEST_OS=centos-8-stream make prepare-check
+    TEST_OS=centos-9-stream make prepare-check
 
 You can also run the test against a different Cockpit image, for example:
 
-    TEST_OS=fedora-34 make check
+    TEST_OS=fedora-40 make check
 
 # Running tests in CI
 

--- a/packit.yaml
+++ b/packit.yaml
@@ -26,7 +26,6 @@ jobs:
     targets:
     - fedora-all
     - fedora-latest-aarch64
-    - centos-stream-8
     - centos-stream-9
     - centos-stream-9-aarch64
     - centos-stream-10
@@ -36,7 +35,6 @@ jobs:
     targets:
       - fedora-all
       - fedora-latest-aarch64
-      - centos-stream-8
       - centos-stream-9
       - centos-stream-9-aarch64
       - centos-stream-10

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -23,7 +23,7 @@ mv .git dot-git
 . /run/host/usr/lib/os-release
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 
-if [ "$TEST_OS" = "centos-8" ] || [ "$TEST_OS" = "centos-9" ]; then
+if [ "$TEST_OS" = "centos-9" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 


### PR DESCRIPTION
C8S is going to be EOL in a month [1], and we are not going to do a RHEL 8 update at this point any more.

Keep testing on rhel-8-10 though, as we do want to keep the code working for the beiboot scenario or backports.

[1] https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/