### PR TITLE
.eslintrc.json: boolean values are deprecated for globals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,7 @@
         "standard/no-callback-literal": "off"
     },
     "globals": {
-        "require": false,
-        "module": false
+        "require": "readonly",
+        "module": "readonly"
     }
 }


### PR DESCRIPTION
As per ESLint docs these options still allow boolean values but in reality they are deprecated and replaced by "readonly". Oxlint currently cannot deal with this and therefore cannot parse the eslint configuration file.

https://eslint.org/docs/latest/use/configure/language-options#using-configuration-files