### PR TITLE
Makefile: use `XZ_OPT=-0` for `make vm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ rpm: $(TARFILE) $(NODE_CACHE) $(SPEC)
 
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
+$(VM_IMAGE): export XZ_OPT=-0
 $(VM_IMAGE): $(TARFILE) $(NODE_CACHE) bots test/vm.install
 	bots/image-customize --no-network --fresh \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \


### PR DESCRIPTION
...and targets which depend on it, like `make check`.

This shaves some seconds off of image building.