### PR TITLE
package.json: Explicitly depend on stylelint-config-recommended-scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "qunit": "2.21.0",
     "sass": "1.77.6",
     "stylelint": "16.6.1",
+    "stylelint-config-recommended-scss": "14.0.0",
     "stylelint-config-standard": "36.0.1",
     "stylelint-config-standard-scss": "13.1.0",
     "stylelint-formatter-pretty": "4.0.0"


### PR DESCRIPTION
The latest version 14.1.0 does not work with our other stylelint package versions. Pin down the version we've used so far, and let dependabot take care of grouped updates.

---

Fixes [this spontaneous breakage](https://cockpit-logs.us-east-1.linodeobjects.com/pull-6597-955fba2e-20240710-071959-centos-10-cockpit-project-starter-kit/log.html). We got the same in cockpit in https://github.com/cockpit-project/cockpit/pull/20733 but there we keep n_m in git.