### PR TITLE
Read host name just once

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,7 +32,7 @@ export const Application = () => {
         const hostname = cockpit.file('/etc/hostname');
         hostname.watch(content => setHostname(content?.trim() ?? ""));
         return hostname.close;
-    });
+    }, []);
 
     return (
         <Card>


### PR DESCRIPTION
Add an empty dependency array to useEffect(), to go back to the behaviour since before commit 4bbb291281556.

Thanks to @subhoghoshX for spotting!