### PR TITLE
Add empty dependency array to useEffect hook

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -32,7 +32,7 @@ export const Application = () => {
         const hostname = cockpit.file('/etc/hostname');
         hostname.watch(content => setHostname(content?.trim() ?? ""));
         return hostname.close;
-    });
+    }, []);
 
     return (
         <Card>


### PR DESCRIPTION
This limits the file watch listener to only attach once and not on every render which is unnecessary.