### PR TITLE
package.json: stop providing configured extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "watch": "ESBUILD_WATCH='true' ./build.js",
     "build": "./build.js",
-    "eslint": "eslint --ext .js --ext .jsx src/",
-    "eslint:fix": "eslint --fix --ext .js --ext .jsx src/",
+    "eslint": "eslint src/",
+    "eslint:fix": "eslint --fix src/",
     "stylelint": "stylelint src/*{.css,scss}",
     "stylelint:fix": "stylelint --fix src/*{.css,scss}"
   },


### PR DESCRIPTION
In eslintrc.json we already specify the type of files we are interested in linting and `--ext` takes presence over the configuration file and as no js or jsx files eslint will report an error.