### PR TITLE
CDP replacement candidate: direct python API for BiDi

### DIFF
--- a/bidi-test.py
+++ b/bidi-test.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python3
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+import bidi
+
+
+def jsquote(js: object) -> str:
+    return json.dumps(js)
+
+JsonObject = dict[str, Any]
+
+
+# shape of our testlib.Browser, all sync
+class Browser:
+    driver: bidi.WebdriverBidi
+
+    @staticmethod
+    def asyncio_loop_thread(loop: asyncio.AbstractEventLoop) -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    def __init__(self) -> None:
+        # FIXME: raise to our standard 15
+        self.timeout = 5
+        headless = not bool(os.environ.get("TEST_SHOW_BROWSER", ""))
+        browser = os.environ.get("TEST_BROWSER", "chromium")
+        if browser == "chromium":
+            self.driver = bidi.ChromiumBidi(headless=headless)
+        elif browser == "firefox":
+            self.driver = bidi.FirefoxBidi(headless=headless)
+        else:
+            raise ValueError(f"unknown browser {browser}")
+        self.loop = asyncio.new_event_loop()
+        self.bidi_thread = threading.Thread(target=self.asyncio_loop_thread, args=(self.loop,))
+        self.bidi_thread.start()
+
+        asyncio.run_coroutine_threadsafe(self.driver.start_session(), self.loop).result()
+
+    def close(self):
+        asyncio.run_coroutine_threadsafe(self.driver.close(), self.loop).result()
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.bidi_thread.join()
+
+    def bidi(self, method, **params) -> JsonObject:
+        """Send a Webdriver BiDi command and return the JSON response"""
+
+        return asyncio.run_coroutine_threadsafe(self.driver.bidi(method, **params), self.loop).result()
+
+    def wait_js_cond(self, cond: str, error_description: str = "null") -> None:
+        for _retry in range(5):
+            try:
+                self.bidi("script.evaluate",
+                        expression=f"window.ph_wait_cond(() => {cond}, {self.timeout * 1000}, {error_description})",
+                        awaitPromise=True, target={"context": self.driver.context})
+                return
+            except bidi.WebdriverError as e:
+                # can happen when waiting across page reloads
+                if (
+                    # chromium
+                    "Execution context was destroyed" in str(e) or
+                    "Cannot find context" in str(e) or
+                    # firefox
+                    "MessageHandlerFrame' destroyed" in str(e)
+                   ):
+                    time.sleep(1)
+                else:
+                    raise
+
+    def _wait_present(self, selector: str) -> None:
+        self.wait_js_cond(f"window.ph_find({jsquote(selector)})")
+
+    def wait_visible(self, selector: str) -> None:
+        self._wait_present(selector)
+        self.wait_js_cond(f"window.ph_is_visible({jsquote(selector)})")
+
+    def open(self, href: str) -> None:
+        self.bidi("browsingContext.navigate", context=self.driver.context, url=href, wait="complete")
+
+    def focus(self, selector: str) -> None:
+        self.wait_visible(selector)
+        self.bidi("script.evaluate", expression=f"document.querySelector('{selector}').focus()",
+                  awaitPromise=False, target={"context": self.driver.context})
+
+    def input_text(self, text: str) -> None:
+        actions = []
+        for c in text:
+            actions.append({"type": "keyDown", "value": c})
+            actions.append({"type": "keyUp", "value": c})
+        self.bidi("input.performActions", context=self.driver.context, actions=[
+            {"type": "key", "id": "key-0", "actions": actions}])
+
+    def set_input_text(self, selector: str, val: str) -> None:
+        self.focus(selector)
+        self.input_text(val)
+        # TODO: wait for value
+        time.sleep(0.2)
+
+    def mouse(self, selector: str, button: int = 0, click_count: int = 1) -> None:
+        self.wait_visible(selector)
+        element = self.bidi("script.evaluate", expression=f"window.ph_find({jsquote(selector)})",
+                            awaitPromise=False, target={"context": self.driver.context})["result"]
+
+        actions = [{"type": "pointerMove", "x": 0, "y": 0, "origin": {"type": "element", "element": element}}]
+        for _ in range(click_count):
+            actions.append({"type": "pointerDown", "button": button})
+            actions.append({"type": "pointerUp", "button": button})
+
+        self.bidi("input.performActions", context=self.driver.context, actions=[
+            {
+                "id": "pointer-0",
+                "type": "pointer",
+                "parameters": {"pointerType": "mouse"},
+                "actions": actions,
+            }
+        ])
+
+    def click(self, selector: str) -> None:
+        return self.mouse(selector)
+
+    def wait_text(self, selector: str, text: str) -> None:
+        self.wait_visible(selector)
+        self.wait_js_cond(f"window.ph_text({jsquote(selector)}) == {jsquote(text)}",
+                          error_description=f"() => 'actual text: ' + window.ph_text({jsquote(selector)})")
+
+    def wait_in_text(self, selector: str, text: str) -> None:
+        self.wait_visible(selector)
+        self.wait_js_cond(f"window.ph_text({jsquote(selector)}).includes({jsquote(text)})",
+                          error_description=f"() => 'actual text: ' + window.ph_text({jsquote(selector)})")
+
+    def switch_to_frame(self, name: str | None) -> None:
+        if name is None:
+            self.switch_to_top()
+        else:
+            asyncio.run_coroutine_threadsafe(self.driver.switch_to_frame(name), self.loop).result()
+
+    def switch_to_top(self) -> None:
+        self.driver.switch_to_top()
+
+
+# sync code, like our tests
+logging.basicConfig(level=logging.DEBUG)
+b = Browser()
+try:
+    b.open("http://127.0.0.2:9091")
+
+    b.set_input_text("#login-user-input", "admin")
+    b.set_input_text("#login-password-input", "foobar")
+    b.click("#login-button")
+    b.wait_text("#super-user-indicator", "Limited access")
+
+    b.switch_to_frame("cockpit1:localhost/system")
+    b.wait_in_text(".system-configuration", "Join domain")
+finally:
+    b.close()

--- a/bidi-test.py
+++ b/bidi-test.py
@@ -15,6 +15,22 @@ def jsquote(js: object) -> str:
 
 JsonObject = dict[str, Any]
 
+# https://w3c.github.io/webdriver/#keyboard-actions for encoding key names
+KEY_BACKSPACE = "\uE003"
+KEY_TAB = "\uE004"
+KEY_RETURN = "\uE006"
+KEY_ENTER = "\uE007"
+KEY_SHIFT = "\uE008"
+KEY_CONTROL = "\uE009"
+KEY_ALT = "\uE00A"
+KEY_ESCAPE = "\uE00C"
+KEY_ARROW_LEFT = "\uE012"
+KEY_ARROW_UP = "\uE013"
+KEY_ARROW_RIGHT = "\uE014"
+KEY_ARROW_DOWN = "\uE015"
+KEY_INSERT = "\uE016"
+KEY_DELETE = "\uE017"
+
 
 # shape of our testlib.Browser, all sync
 class Browser:
@@ -87,6 +103,15 @@ class Browser:
         self.bidi("script.evaluate", expression=f"document.querySelector('{selector}').focus()",
                   awaitPromise=False, target={"context": self.driver.context})
 
+    # see https://w3c.github.io/webdriver/#keyboard-actions for encoding key names
+    # and the KEY_* constants for common ones
+    def key(self, value: str) -> None:
+        self.bidi("input.performActions", context=self.driver.context, actions=[
+            {"type": "key", "id": "key-0", "actions": [
+                {"type": "keyDown", "value": value},
+                {"type": "keyUp", "value": value},
+            ]}])
+
     def input_text(self, text: str) -> None:
         actions = []
         for c in text:
@@ -151,7 +176,9 @@ try:
 
     b.set_input_text("#login-user-input", "admin")
     b.set_input_text("#login-password-input", "foobar")
-    b.click("#login-button")
+    # either works
+    # b.click("#login-button")
+    b.key(KEY_ENTER)
     b.wait_text("#super-user-indicator", "Limited access")
 
     b.switch_to_frame("cockpit1:localhost/system")

--- a/bidi.py
+++ b/bidi.py
@@ -127,9 +127,6 @@ class WebdriverBidi:
             "log.entryAdded", "browsingContext.domContentLoaded",
         ])
 
-        test_functions = Path("test-functions.js").read_text()
-        await self.bidi("script.addPreloadScript", functionDeclaration=f"() => {{ {test_functions} }}")
-
         # wait for browser to initialize default context
         for _ in range(10):
             realms = (await self.bidi("script.getRealms"))["realms"]
@@ -193,7 +190,8 @@ class WebdriverBidi:
         """Send a Webdriver BiDi command and return the JSON response"""
 
         payload = json.dumps({"id": self.last_id, "method": method, "params": params})
-        log_proto.debug("ws ← %r", payload)
+        # avoid log spam for preload scripts
+        log_proto.debug("ws ← %r", method if method == "script.addPreloadScript" else payload)
         await self.ws.send_str(payload)
         future = asyncio.get_event_loop().create_future()
         self.pending_commands[self.last_id] = future

--- a/bidi.py
+++ b/bidi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import asyncio
+import base64
 import json
 import logging
 import socket
@@ -436,7 +437,12 @@ async def main():
         # await d.wait_page_load()
 
         print("\n\nSTEP: super-user-indicator")
-        await d.wait("#super-user-indicator")
+        try:
+            await d.wait("#super-user-indicator")
+        except ValueError:
+            s = await d.bidi("browsingContext.captureScreenshot", context=d.top_context, origin="document")
+            Path("screenshot.png").write_bytes(base64.b64decode(s["data"]))
+            raise
         # FIXME: wait for text helper
         for _ in range(5):
             t = await d.text("#super-user-indicator")

--- a/bidi.py
+++ b/bidi.py
@@ -140,10 +140,6 @@ class WebdriverBidi:
         else:
             raise WebdriverError("timed out waiting for default realm")
 
-        # avoid not seeing elements due to too small window
-        # await self.bidi("browsingContext.setViewport", context=self.top_context,
-        #                 viewport={"width": 1024, "height": 5000})
-
     async def __aenter__(self):
         await self.start_session()
         return self

--- a/bidi.py
+++ b/bidi.py
@@ -1,0 +1,113 @@
+import json
+import logging
+import subprocess
+import time
+import urllib.request
+
+import asyncio
+import websockets
+
+
+logger = logging.getLogger(__name__)
+
+
+class WebdriverError(RuntimeError):
+    pass
+
+
+class WebdriverBidi:
+    def __init__(self, browser) -> None:
+        # TODO: make dynamic
+        self.webdriver_port = 12345
+        self.webdriver_url = f"http://localhost:{self.webdriver_port}"
+
+        session_args = {"capabilities": {
+            "alwaysMatch": {
+                "webSocketUrl": True,
+                "goog:chromeOptions": {"binary": "/usr/bin/chromium-browser"},
+            }
+        }}
+
+        if browser == 'chromium':
+            # add --verbose for debugging
+            self.driver = subprocess.Popen(["chromedriver", "--port=" + str(self.webdriver_port)])
+        elif browser == 'firefox':
+            # TODO: not packaged, get from https://github.com/mozilla/geckodriver/releases
+            self.driver = subprocess.Popen(["/tmp/geckodriver", "--port", str(self.webdriver_port)])
+        else:
+            raise ValueError(f"unknown browser {browser}")
+
+        req = urllib.request.Request(
+                f"{self.webdriver_url}/session",
+                json.dumps(session_args).encode(),
+                headers={"Content-Type": "application/json"})
+        # webdriver needs some time to launch
+        for retry in range(1, 10):
+            try:
+                with urllib.request.urlopen(req) as f:
+                    resp = json.load(f)
+                    break
+            except urllib.error.URLError as e:
+                logger.debug("waiting for webdriver: %s", e)
+                time.sleep(0.1 * retry)
+        else:
+            raise WebdriverError("could not connect to webdriver")
+
+        self.session_info = resp["value"]
+        self.last_id = 0
+        self.ws = None
+        self.pending_commands: dict[int, asyncio.Future] = {}
+
+    async def ws_reader(self) -> None:
+        assert self.ws
+        while True:
+            try:
+                ret = json.loads(await self.ws.recv())
+            except websockets.exceptions.ConnectionClosedOK:
+                logger.debug("ws_reader connection closed")
+                break
+            logger.debug("ws → %r", ret)
+            if ret["id"] in self.pending_commands:
+                logger.debug("ws_reader: resolving pending command %i", ret["id"])
+                if ret["type"] == "success":
+                    self.pending_commands[ret["id"]].set_result(ret["result"])
+                else:
+                    self.pending_commands[ret["id"]].set_exception(WebdriverError(f"{ret['type']}: {ret['message']}"))
+                del self.pending_commands[ret["id"]]
+
+    async def command(self, method, **params) -> asyncio.Future:
+        assert self.ws
+        payload = json.dumps({"id": self.last_id, "method": method, "params": params})
+        logger.debug("ws ← %r", payload)
+        await self.ws.send(payload)
+        future = asyncio.get_event_loop().create_future()
+        self.pending_commands[self.last_id] = future
+        self.last_id += 1
+        return await future
+
+    async def run(self):
+        # open bidi websocket for session
+        async with websockets.connect(self.session_info["capabilities"]["webSocketUrl"]) as ws:
+            self.ws = ws
+            self.task_reader = asyncio.create_task(self.ws_reader(), name="bidi_reader")
+
+            await self.command("session.subscribe", events=["log.entryAdded"])
+            context = (await self.command("browsingContext.create", type="tab"))["context"]
+            await self.command("browsingContext.navigate", context=context, url="https://piware.de")
+
+            await asyncio.sleep(5)
+            self.task_reader.cancel()
+            del self.task_reader
+
+    def __del__(self):
+        logger.debug("cleaning up webdriver")
+        urllib.request.urlopen(urllib.request.Request(
+            f"{self.webdriver_url}/session/{self.session_info['sessionId']}", method="DELETE"))
+
+        self.driver.terminate()
+        self.driver.wait()
+
+
+logging.basicConfig(level=logging.DEBUG)
+d = WebdriverBidi("chromium")  # or firefox
+asyncio.run(d.run())

--- a/bidi.py
+++ b/bidi.py
@@ -116,6 +116,9 @@ class WebdriverBidi:
         else:
             raise WebdriverError("timed out waiting for default realm")
 
+        # avoid not seeing elements due to too small window
+        await self.bidi("browsingContext.setViewport", context=self.context, viewport={"width": 1024, "height": 5000})
+
     async def __aenter__(self):
         await self.start_session()
         return self

--- a/bidi.py
+++ b/bidi.py
@@ -16,6 +16,12 @@ logger = logging.getLogger(__name__)
 # https://w3c.github.io/webdriver/#dfn-find-elements
 EL_ID = 'element-6066-11e4-a52e-4f735466cecf'
 
+DRIVERS = {
+    "chromium": "chromedriver",
+    # TODO: not packaged, get from https://github.com/mozilla/geckodriver/releases
+    "firefox": "/tmp/geckodriver",
+}
+
 
 class WebdriverError(RuntimeError):
     pass
@@ -58,14 +64,10 @@ class WebdriverBidi:
             }
         }}
 
-        if browser == 'chromium':
-            # add --verbose for debugging
-            self.driver = subprocess.Popen(["chromedriver", "--port=" + str(self.webdriver_port)])
-        elif browser == 'firefox':
-            # TODO: not packaged, get from https://github.com/mozilla/geckodriver/releases
-            self.driver = subprocess.Popen(["/tmp/geckodriver", "--port", str(self.webdriver_port)])
-        else:
-            raise ValueError(f"unknown browser {browser}")
+        try:
+            self.driver = subprocess.Popen([DRIVERS[browser], "--port=" + str(self.webdriver_port)])
+        except KeyError as e:
+            raise ValueError(f"unknown browser {browser}") from e
 
         req = urllib.request.Request(
                 f"{self.webdriver_url}/session",

--- a/bidi.py
+++ b/bidi.py
@@ -480,4 +480,5 @@ async def main():
             log_command.info(log)
 
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bidi.py
+++ b/bidi.py
@@ -201,11 +201,13 @@ class WebdriverBidi:
         r = (await self.bidi("browsingContext.locateNodes", context=context,
                              locator={"type": "css", "value": "#menu-content"}))["nodes"]
         assert len(r) == 1
-        menu_content_id = r[0]['sharedId']
 
         # this doensn't yet have a BiDi command
-        r = await self.webdriver(f"/element/{menu_content_id}/text")
-        assert 'ADDICTED TO FREE SOFTWARE DEVELOPMENT' in r['value']
+        # r = await self.webdriver(f"/element/{r[0]['sharedId']}/text")
+        # ... but we don't need it, our CDP driver does this too:
+        r = await self.bidi("script.evaluate", expression="document.querySelector('#menu-content').textContent",
+                            awaitPromise=False, target={"context": context})
+        assert 'Addicted to Free Software Development' in r['result']['value']
 
         # locate first social link
         r = (await self.bidi("browsingContext.locateNodes", context=context,

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jed": "1.1.1",
     "qunit": "2.21.1",
     "sass": "1.77.8",
+    "sizzle": "2.3.10",
     "stylelint": "16.7.0",
     "stylelint-config-recommended-scss": "14.0.0",
     "stylelint-config-standard": "36.0.1",

--- a/test-functions.js
+++ b/test-functions.js
@@ -1,0 +1,75 @@
+window.ph_select = function(sel) {
+    if (!window.Sizzle) {
+        return Array.from(document.querySelectorAll(sel));
+    }
+
+    if (sel.includes(":contains(")) {
+        if (!window.Sizzle) {
+            throw new Error("Using ':contains' when window.Sizzle is not available.");
+        }
+        return window.Sizzle(sel);
+    } else {
+        return Array.from(document.querySelectorAll(sel));
+    }
+};
+
+window.ph_find = function(sel) {
+    const els = window.ph_select(sel);
+    if (els.length === 0)
+        throw new Error(sel + " not found");
+    if (els.length > 1)
+        throw new Error(sel + " is ambiguous");
+    return els[0];
+};
+
+window.ph_text = function(sel) {
+    const el = window.ph_find(sel);
+    if (el.textContent === undefined)
+        throw new Error(sel + " can not have text");
+    // 0xa0 is a non-breakable space, which is a rendering detail of Chromium
+    // and awkward to handle in tests; turn it into normal spaces
+    return el.textContent.replaceAll("\xa0", " ");
+};
+
+window.ph_is_visible = function(sel) {
+    const el = window.ph_find(sel);
+    return el.tagName === "svg" || ((el.offsetWidth > 0 || el.offsetHeight > 0) && !(el.style.visibility === "hidden" || el.style.display === "none"));
+};
+
+class PhWaitCondTimeout extends Error {
+    constructor(description) {
+        if (description && description.apply)
+            description = description.apply();
+        if (description)
+            super(description);
+        else
+            super("condition did not become true");
+    }
+}
+
+window.ph_wait_cond = function (cond, timeout, error_description) {
+    return new Promise((resolve, reject) => {
+        // poll every 100 ms for now;  FIXME: poll less often and re-check on mutations using
+        // https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+        let stepTimer = null;
+        let last_err = null;
+        const tm = window.setTimeout(() => {
+            if (stepTimer)
+                window.clearTimeout(stepTimer);
+            reject(last_err || new PhWaitCondTimeout(error_description));
+        }, timeout);
+        function step() {
+            try {
+                if (cond()) {
+                    window.clearTimeout(tm);
+                    resolve();
+                    return;
+                }
+            } catch (err) {
+                last_err = err;
+            }
+            stepTimer = window.setTimeout(step, 100);
+        }
+        step();
+    });
+};

--- a/test-functions.js
+++ b/test-functions.js
@@ -1,8 +1,4 @@
 window.ph_select = function(sel) {
-    if (!window.Sizzle) {
-        return Array.from(document.querySelectorAll(sel));
-    }
-
     if (sel.includes(":contains(")) {
         if (!window.Sizzle) {
             throw new Error("Using ':contains' when window.Sizzle is not available.");

--- a/test/run
+++ b/test/run
@@ -1,5 +1,5 @@
 #! /bin/sh
-set -eu
+set -eux
 
 # This is the expected entry point for Cockpit CI; will be called without
 # arguments but with an appropriate $TEST_OS, and optionally $TEST_SCENARIO
@@ -8,5 +8,15 @@ TEST_SCENARIO="${TEST_SCENARIO:-}"
 [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
 export RUN_TESTS_OPTIONS=--track-naughties
 
-make codecheck
-make check
+make prepare-check
+
+bots/machine/testvm.py $TEST_OS &
+VM_PID=$!
+trap "kill $VM_PID" EXIT INT QUIT PIPE
+
+# Wait for the VM to be ready
+until nc -z 127.0.0.2 2201; do
+    sleep 1
+done
+
+./bidi-test.py


### PR DESCRIPTION
This is another candidate for https://issues.redhat.com/browse/COCKPIT-1139 , in the similar spirit as #926

This talks to https://w3c.github.io/webdriver-bidi/ directly, requires *zero* new npm dependencies (in fact, we can drop chrome-remote-interface), and only a new package (`chromedriver`) in the tasks container (~installed locally for this demo~ added to official container now).

This is much further ahead than #926, in the sense of that it actually is a Python test, in our usual testlib shape. We won't need any extra `node` process to talk to a JS webdriver module any more, and they aren't any good ones for BiDi anyway.

Compared to CDP this has the following advantages:
 * Fewer moving parts and less code
 * At the API level, Firefox and Chromium behave the same, so we can drop our `{firefox,chromium}-cdp-driver.js` forks
 * Very low input API level, we can even simulate touch swipes and others. With CDP we just synthesize a `MouseEvent`, while this *actually* goes through the browser.

Hiccups:
 - [x] Land and deploy https://github.com/cockpit-project/cockpituous/pull/622 to use the packaged chromedriver (#935 ), then drop the local download
 - [x]  that `input.performActions` does not understand key names like "Return" or "ArrowUp".  https://github.com/w3c/webdriver-bidi/issues/757
 - [x] clicks in frames miss their target in chrome (works fine with Firefox)
 - [x] When showing the browser, the test sometimes crashes with something like "target is outside of viewport". needs scrollIntoView() or so (I remember this from Selenium)
 - [x] Check how to enable coverage (if no API, then via a single CDP call or some other hack)
 - [x] Test loading/using sizzle

https://issues.redhat.com/browse/COCKPIT-1154