### PR TITLE
build.js: prefer startsWith over regex with a caret

### DIFF
--- a/build.js
+++ b/build.js
@@ -57,8 +57,7 @@ function watch_dirs(dir, on_change) {
     const callback = (ev, dir, fname) => {
         // only listen for "change" events, as renames are noisy
         // ignore hidden files
-        const isHidden = /^\./.test(fname);
-        if (ev !== "change" || isHidden) {
+        if (ev !== "change" || fname.startsWith('.')) {
             return;
         }
         on_change(path.join(dir, fname));


### PR DESCRIPTION
Found by eslint-plugin-unicorn.

---

I personally prefer this simplification, it is also present in machines (not podman/files/cockpit)