### PR TITLE
appstream: Fix validation problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TARFILE=$(RPM_NAME)-$(VERSION).tar.xz
 NODE_CACHE=$(RPM_NAME)-node-$(VERSION).tar.xz
 SPEC=$(RPM_NAME).spec
 PREFIX ?= /usr/local
-APPSTREAMFILE=org.cockpit-project.$(PACKAGE_NAME).metainfo.xml
+APPSTREAMFILE=org.cockpit_project.$(subst -,_,$(PACKAGE_NAME)).metainfo.xml
 VM_IMAGE=$(CURDIR)/test/images/$(TEST_OS)
 # stamp file to check for node_modules/
 NODE_MODULES_TEST=package-lock.json

--- a/org.cockpit_project.starter_kit.metainfo.xml
+++ b/org.cockpit_project.starter_kit.metainfo.xml
@@ -7,6 +7,9 @@
   <description>
     <p>
       Scaffolding for a cockpit module.
+
+      This is just a demo which does not do much. Please replace
+      this with a real description.
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
@@ -14,4 +17,7 @@
   <url type="homepage">https://github.com/cockpit-project/starter-kit</url>
   <url type="bugtracker">https://github.com/cockpit-project/starter-kit/issues</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
+  <developer id="org.cockpit-project">
+    <name>Cockpit Project</name>
+  </developer>
 </component>


### PR DESCRIPTION
Rename the file to match its ID, add developer tag, and extend the description. This fixes all issues with `appstreamcli validate`:

> I: org.cockpit_project.starter_kit:10: description-first-para-too-short
>      Scaffolding for a cockpit module.
> I: org.cockpit_project.starter_kit: developer-info-missing
> W: org.cockpit_project.starter_kit: metainfo-filename-cid-mismatch