### PR TITLE
dependabot: Fix PatternFly update-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
 
       # needs to be done in Cockpit first
       - dependency-name: "@patternfly/*"
-        update-types: ["major"]
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Commit 52184d910f was ineffective due to `update-types` not having a correct value. See
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore

Closes #1020