### PR TITLE
package.json: Downgrade sass to 1.79

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "htmlparser": "1.7.7",
     "jed": "1.1.1",
     "qunit": "2.22.0",
-    "sass": "1.80.3",
+    "sass": "1.79.6",
     "stylelint": "16.10.0",
     "stylelint-config-recommended-scss": "14.0.0",
     "stylelint-config-standard": "36.0.1",


### PR DESCRIPTION
sass 1.80 (and 2.x) introduces tons of "@import rules are deprecated". These are unfixable on our side due to PatternFly using them extensively.

We don't need any new sass features, so stick to 1.79.x. Explicitly not ignore 3.x (which will drop @import) to get a reminder in the future to try and clean this up again.

Same as https://github.com/cockpit-project/cockpit/pull/21155

The dependabot change from commit 6cc062f76f77d11a8 will prevent updates in the future, but it landed when package.json already had 1.80.