### PR TITLE
dependabot: Ignore 1.8x versions as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
     ignore:
       # https://github.com/cockpit-project/cockpit/issues/21151
       - dependency-name: "sass"
-        versions: ["1.80.x", "2.x"]
+        versions: [">=1.80.0", "2.x"]
 
       # needs to be done in Cockpit first
       - dependency-name: "@patternfly/*"


### PR DESCRIPTION
sass is at 1.81.0 now, which we also don't want -- we want to stay on 1.79.x for the time being.

---

@jelly Found that syntax here: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore-updates-beyond-a-specific-version