### PR TITLE
packit: Drop copr_build job redundancy

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -23,12 +23,8 @@ actions:
 jobs:
   - job: copr_build
     trigger: pull_request
-    targets:
-    - fedora-all
-    - fedora-latest-aarch64
-    - centos-stream-9
-    - centos-stream-9-aarch64
-    - centos-stream-10
+    # only extra build-only targets; targets in "tests" are implicitly built
+    targets: []
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
It's exactly the same OS list as for `tests`. We only need to specify the additional build targets, but we don't have any.

---

I'm also curious if fedora-42 actually works now -- it should be part of "fedora-all".