### PR TITLE
git: Add generated specfiles to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /Test*.png
 /*.whl
 /bots
+/cockpit-*.spec
 /cockpit-*.tar.xz
 /cockpit-navigator.spec
 /dist/


### PR DESCRIPTION
Otherwise they'll be added to the commit for new projects using the
starter kit

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
