### PR TITLE
Enclose `<Card>` by a `<Page>` component to prevent card from sticking to sidebar

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,7 @@
 import React, { useEffect, useState } from 'react';
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Card, CardBody, CardTitle } from "@patternfly/react-core/dist/esm/components/Card/index.js";
+import { Page } from '@patternfly/react-core/dist/esm/components/Page/index.js';
 
 import cockpit from 'cockpit';
 
@@ -22,14 +23,16 @@ export const Application = () => {
     }, []);
 
     return (
-        <Card>
-            <CardTitle>Starter Kit</CardTitle>
-            <CardBody>
-                <Alert
+        <Page className='pf-m-no-sidebar'>
+            <Card>
+                <CardTitle>Starter Kit</CardTitle>
+                <CardBody>
+                    <Alert
                     variant="info"
                     title={ cockpit.format(_("Running on $0"), hostname) }
-                />
-            </CardBody>
-        </Card>
+                    />
+                </CardBody>
+            </Card>
+        </Page>
     );
 };


### PR DESCRIPTION
Closes #1447 

This PR modifies `app.tsx` to enclose the Card component into another `Page` component with the CSS class `pf-m-no-sidebar` so the Card in starter file doesn't stick to Cockpit's sidebar.

Should make the process for creating their first plugin for first time users a bit more easier.

## Screenshots

### Before

<img width="1926" height="470" alt="Image" src="https://github.com/user-attachments/assets/63ecd626-cbe3-40d4-aef8-43b9421e9e56" />

### After

<img width="1926" height="470" alt="Image" src="https://github.com/user-attachments/assets/86063c42-9bc4-4c79-997d-ed29e9ac1d3f" />

Thanks!