### PR TITLE
dependabot: ignore TypeScript 7 for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,11 @@ updates:
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
 
+      # @typescript-eslint is incompatible with TS 7
+      # https://github.com/typescript-eslint/typescript-eslint/issues/12518
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 3


### PR DESCRIPTION
typescript-eslint will not support it for a while